### PR TITLE
Clean up capitalization, etc. in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # `BLUES`: Binding modes of Ligands Using Enhanced Sampling
 <img align="right" src="./images/blues.png" width="300">
 
-This package takes advantage of non-candidate equilibrium monte carlo moves (NCMC) to help sample between different ligand binding modes.
-
-This also provides a prototype and validation of the SMIRFF SMIRKS-based force field format, along with classes to parameterize OpenMM systems given [SMIRFF `.ffxml` format files](https://github.com/open-forcefield-group/smarty/blob/master/The-SMIRFF-force-field-format.md) as provided here.
+This package takes advantage of non-equilibrium candidate Monte Carlo moves (NCMC) to help sample between different ligand binding modes.
 
 Latest release: [![DOI](https://zenodo.org/badge/62096511.svg)](https://zenodo.org/badge/latestdoi/62096511)
 
@@ -35,14 +33,14 @@ python setup.py install
 
 ### BLUES using NCMC
 
-This package takes advantage of non-candidate equilibrium monte carlo moves (NCMC) to help sample between different ligand binding modes using the OpenMM simulation package. Currently the innate functionality is found in `blues/ncmc.py`, which utilizes a lambda coupling to alter the sterics and electrostatics of the ligand over the course of the ncmc move. One goal for this package is to allow for easy additions of other moves of interest, which will be covered below.
+This package takes advantage of non-equilibrium candidate Monte Carlo moves (NCMC) to help sample between different ligand binding modes using the OpenMM simulation package. Currently the innate functionality is found in `blues/ncmc.py`, which utilizes a lambda coupling to alter the sterics and electrostatics of the ligand over the course of the NCMC move. One goal for this package is to allow for easy additions of other moves of interest, which will be covered below.
 
 ### Example Use
 An example of how to set up a simulation sampling the binding modes of toluene bound to T4 lysozyme using NCMC and a rotational move can be found in `blues/example.py`
 
 ### Actually using BLUES
 The heart of the package is found in `blues/ncmc_switching.py`. This holds the framework for NCMC. Particularly, it contains the integrator class that calculates the work done during the NCMC move. It also controls the lambda scaling of parameters. Currently the alchemy package is used to generate the lambda parameters for the ligand, which can potentially modify 5 parameters–sterics, electrostatics, bonds, angles, and torsions.
-The `Simulation` class in `blues/simulation.py` serves as a wrapper for running ncmc simulations.
+The `Simulation` class in `blues/simulation.py` serves as a wrapper for running NCMC simulations.
 
 ###### For a detailed explanation of the BLUES framework or implementing new moves, check out the [README](devdocs/README.md) in devdocs.
 


### PR DESCRIPTION
README fixes: Fixes capitalization, a SMIRNOFF-related phrase which was here for who knows what reason (maybe copied from another README accidentally?), and a mis-ordered phrase which occurred twice.