### PR TITLE
Fix missing constraints on HBonds, silence alchemy warnings

### DIFF
--- a/blues/ncmc.py
+++ b/blues/ncmc.py
@@ -226,6 +226,8 @@ class SimulationFactory(object):
         atom_indices : list
             Atom indicies of the model.
         """
+        import logging
+        logging.getLogger("openmmtools.alchemy").setLevel(logging.ERROR)
         factory = alchemy.AlchemicalFactory()
         alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices)
         alch_system = factory.create_alchemical_system(system, alch_region)
@@ -243,7 +245,7 @@ class SimulationFactory(object):
         """
         system = structure.createSystem(nonbondedMethod=eval("app.%s" % nonbondedMethod),
                             nonbondedCutoff=nonbondedCutoff*unit.angstroms,
-                            constraints=None)
+                            constraints=eval("app.%s" % constraints) )
         return system
 
     def generateSimFromStruct(self, structure, system, nIter, nstepsNC, nstepsMD,

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -210,7 +210,7 @@ class Simulation(object):
         self.nc_integrator.reset()
         self.md_sim.context.setVelocitiesToTemperature(self.temperature)
 
-    def simulateNCMC(self):
+    def simulateNCMC(self, verbose=False):
         """Function that performs the NCMC simulation."""
         for nc_step in range(self.nstepsNC):
             try:
@@ -232,7 +232,7 @@ class Simulation(object):
                 # Calculate Work/Energies After Step.
                 work_final = self.getWorkInfo(self.nc_integrator, self.work_keys)
 
-                if self.verbose:
+                if verbose:
                     print('Initial work:', work_initial)
                     print('Final work:', work_final)
                     #TODO write out frame regardless if accepted/REJECTED


### PR DESCRIPTION
This address issue #68 where the constraints to the HBonds was dropped.

I've also adding a line to silence the warning messages (temporarily) from `openmm.alchemy` from issue #58 