### PR TITLE
[WIP] Integrator fix by checking for precision

### DIFF
--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -166,6 +166,6 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)
-        self.addComputeGlobal("perturbed_pe", "0")
-        self.addComputeGlobal("unperturbed_pe", "0")
+        self.setGlobalVariableByName("perturbed_pe", "0")
+        self.setGlobalVariableByName("unperturbed_pe", "0")
 

--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -166,6 +166,6 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)
-        self.setGlobalVariableByName("perturbed_pe", "0")
-        self.setGlobalVariableByName("unperturbed_pe", "0")
+        self.setGlobalVariableByName("perturbed_pe", 0.0)
+        self.setGlobalVariableByName("unperturbed_pe", 0.0)
 

--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -1,7 +1,7 @@
-from openmmtools.integrators import NonequilibriumLangevinIntegrator
+from openmmtools.integrators import AlchemicalNonequilibriumLangevinIntegrator
 import simtk
 
-class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator):
+class NonequilibriumExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinIntegrator):
     """
     NOTE: Currently a vestigal integrator (not used in the other parts of
     the BLUES code). May possibly be used in a later release.

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -78,8 +78,8 @@ class Simulation(object):
         else:
             self.verbose = False
 
-        self.work_keys = ['total_work', 'lambda', 'shadow_work',
-                          'protocol_work']
+        self.work_keys = [ 'lambda', 'shadow_work',
+                          'protocol_work', 'Eold', 'Enew']
 
         self.state_keys = { 'getPositions' : True,
                        'getVelocities' : True,
@@ -196,13 +196,20 @@ class Simulation(object):
             self.setSimState('alch', 'state1', alch_state1)
             correction_factor = (nc_state0['potential_energy'] - md_state0['potential_energy'] + alch_state1['potential_energy'] - nc_state1['potential_energy']) * (-1.0/self.nc_integrator.kT)
             log_ncmc = log_ncmc + correction_factor
-
-        if log_ncmc > randnum:
+        print('log_ncmc', log_ncmc)
+        print('poten', nc_state1['potential_energy']._value)
+        if abs(nc_state1['potential_energy']._value) > 2147483640.:
+            self.reject += 1
+            print('NCMC MOVE REJECTED: potential energy {} > precision'.format(nc_state1['potential_energy']))
+            self.nc_context.setPositions(md_state0['positions'])
+        #else check acceptance criteria for acceptance/rejection
+        elif log_ncmc >= randnum:
             self.accept += 1
             print('NCMC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_ncmc, randnum) )
             self.md_sim.context.setPositions(nc_state1['positions'])
-            #self.writeFrame(self.md_sim, 'MD-iter{}.pdb'.format(self.current_iter))
-        else:
+            self.writeFrame(self.md_sim, 'MD-iter{}.pdb'.format(self.current_iter))
+
+        elif log_ncmc < randnum:
             self.reject += 1
             print('NCMC MOVE REJECTED: {} < {}'.format(log_ncmc, randnum) )
             self.nc_context.setPositions(md_state0['positions'])

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -78,7 +78,7 @@ class Simulation(object):
         else:
             self.verbose = False
 
-        self.work_keys = [ 'lambda', 'shadow_work',
+        self.work_keys = ['lambda', 'shadow_work',
                           'protocol_work', 'Eold', 'Enew']
 
         self.state_keys = { 'getPositions' : True,
@@ -196,8 +196,8 @@ class Simulation(object):
             self.setSimState('alch', 'state1', alch_state1)
             correction_factor = (nc_state0['potential_energy'] - md_state0['potential_energy'] + alch_state1['potential_energy'] - nc_state1['potential_energy']) * (-1.0/self.nc_integrator.kT)
             log_ncmc = log_ncmc + correction_factor
-        print('log_ncmc', log_ncmc)
-        print('poten', nc_state1['potential_energy']._value)
+
+        #check if potential energy is greater then precision and reject if that's the case
         if abs(nc_state1['potential_energy']._value) > 2147483640.:
             self.reject += 1
             print('NCMC MOVE REJECTED: potential energy {} > precision'.format(nc_state1['potential_energy']))
@@ -209,7 +209,7 @@ class Simulation(object):
             self.md_sim.context.setPositions(nc_state1['positions'])
             self.writeFrame(self.md_sim, 'MD-iter{}.pdb'.format(self.current_iter))
 
-        elif log_ncmc < randnum:
+        elif log_ncmc < randnum or np.isnan(log_ncmc):
             self.reject += 1
             print('NCMC MOVE REJECTED: {} < {}'.format(log_ncmc, randnum) )
             self.nc_context.setPositions(md_state0['positions'])
@@ -288,7 +288,7 @@ class Simulation(object):
         for n in range(self.nIter):
             self.current_iter = int(n)
             self.setStateConditions()
-            self.simulateNCMC()
+            self.simulateNCMC(verbose=self.verbose)
             self.chooseMove()
             self.simulateMD()
 


### PR DESCRIPTION
This pull request mainly addresses the issue of accepting unfavorable moves that get accepted due to precision issues when the potential energies get too large and precision affects the accumulated protocol work.

This also addresses the issue of the verbose option for blues.simulation not being properly applied, and which integrator parameters are printed during debugging.