### PR TITLE
Options to get NCMC simulation output

### DIFF
--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -1,7 +1,10 @@
-from openmmtools.integrators import NonequilibriumLangevinIntegrator
+from openmmtools.integrators import AlchemicalNonequilibriumLangevinIntegrator
 import simtk
 
-class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator):
+# Energy unit used by OpenMM unit system
+_OPENMM_ENERGY_UNIT = simtk.unit.kilojoules_per_mole
+
+class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinIntegrator):
     """
     NOTE: Currently a vestigal integrator (not used in the other parts of
     the BLUES code). May possibly be used in a later release.
@@ -63,7 +66,7 @@ class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator)
                  measure_shadow_work=False,
                  measure_heat=True,
                  nsteps_neq=100,
-                 steps_per_propagation=1):
+                 *args, **kwargs):
         """
         Parameters
         ----------
@@ -92,14 +95,8 @@ class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator)
             Number of steps in nonequilibrium protocol. Default 100
         """
 
-#        self._alchemical_functions = alchemical_functions
-#        self._n_steps_neq = nsteps_neq
-
-        # collect the system parameters.
-#        self._system_parameters = {system_parameter for system_parameter in alchemical_functions.keys()}
-
         # call the base class constructor
-        super(NonequilibriumExternalLangevinIntegrator, self).__init__(alchemical_functions=alchemical_functions,
+        super(AlchemicalExternalLangevinIntegrator, self).__init__(alchemical_functions=alchemical_functions,
                                                                splitting=splitting, temperature=temperature,
                                                                collision_rate=collision_rate, timestep=timestep,
                                                                constraint_tolerance=constraint_tolerance,
@@ -109,45 +106,57 @@ class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator)
                                                                )
 
         # add some global variables relevant to the integrator
-        ##self.add_global_variables(nsteps=nsteps_neq)
         kB = simtk.unit.BOLTZMANN_CONSTANT_kB * simtk.unit.AVOGADRO_CONSTANT_NA
         kT = kB * temperature
-        self.kT = kT
         self.addGlobalVariable("perturbed_pe", 0)
         self.addGlobalVariable("unperturbed_pe", 0)
         self.addGlobalVariable("first_step", 0)
-        self.addGlobalVariable("psteps", steps_per_propagation)
-        self.addGlobalVariable("pstep", 0)
         try:
             self.getGlobalVariableByName("shadow_work")
         except:
             self.addGlobalVariable('shadow_work', 0)
 
-    def add_integrator_steps(self, splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts):
+    def _add_integrator_steps(self):
+        """
+        Override the base class to insert reset steps around the integrator.
+        """
+
+        # First step: Constrain positions and velocities and reset work accumulators and alchemical integrators
+        self.beginIfBlock('step = 0')
         self.addComputeGlobal("perturbed_pe", "energy")
-        # Assumes no perturbation is done before doing the initial MD step.
-        self.beginIfBlock("first_step < 1")
-        self.addComputeGlobal("first_step", "1")
         self.addComputeGlobal("unperturbed_pe", "energy")
+        self.addConstrainPositions()
+        self.addConstrainVelocities()
+        self._add_reset_protocol_work_step()
+        self._add_alchemical_reset_step()
         self.endBlock()
-        self.addComputeGlobal("perturbed_pe", "energy")
-        self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)/kT")
-        #repeat BAOAB integration psteps number of times per lambda
-        self.addComputeGlobal("pstep", "0")
-        self.beginWhileBlock('pstep < psteps')
-        super(NonequilibriumExternalLangevinIntegrator, self).add_integrator_steps(splitting, measure_shadow_work, measure_heat, ORV_counts, force_group_nV, mts)
-        self.beginIfBlock("pstep < psteps - 1")
-        self.addComputeGlobal("step", "step - 1")
-        self.endBlock()
-        self.addComputeGlobal("pstep", "pstep + 1")
-        self.endBlock()
-        #update unperturbed_pe
-        self.addComputeGlobal("unperturbed_pe", "energy")
+
+        # Main body
+        if self._n_steps_neq == 0:
+            # If nsteps = 0, we need to force execution on the first step only.
+            self.beginIfBlock('step = 0')
+            super(AlchemicalNonequilibriumLangevinIntegrator, self)._add_integrator_steps()
+            self.addComputeGlobal("step", "step + 1")
+            self.endBlock()
+        else:
+            #call the superclass function to insert the appropriate steps, provided the step number is less than n_steps
+            self.beginIfBlock("step < nsteps")
+            self.addComputeGlobal("perturbed_pe", "energy")
+            self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
+
+            super(AlchemicalNonequilibriumLangevinIntegrator, self)._add_integrator_steps()
+
+            self.addComputeGlobal("unperturbed_pe", "energy")
+            self.addComputeGlobal("step", "step + 1")
+
+            self.endBlock()
+
 
     def getLogAcceptanceProbability(self, context):
+        #TODO remove context from arguments if/once ncmc_switching is changed
         protocol = self.getGlobalVariableByName("protocol_work")
         shadow = self.getGlobalVariableByName("shadow_work")
-        logp_accept = -1.0*(protocol + shadow)
+        logp_accept = -1.0*(protocol + shadow)*_OPENMM_ENERGY_UNIT / self.kT
         return logp_accept
 
     def reset(self):
@@ -157,3 +166,6 @@ class NonequilibriumExternalLangevinIntegrator(NonequilibriumLangevinIntegrator)
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)
+        self.setGlobalVariableByName("perturbed_pe", 0.0)
+        self.setGlobalVariableByName("unperturbed_pe", 0.0)
+

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -222,10 +222,10 @@ class Simulation(object):
         self.nc_integrator.reset()
         self.md_sim.context.setVelocitiesToTemperature(self.temperature)
 
-    def simulateNCMC(self, verbose=False):
+    def simulateNCMC(self, verbose=False, write_ncmc=False):
         """Function that performs the NCMC simulation."""
         #append nc reporter at the first step
-        if (self.current_iter == 0) and (self.write_ncmc is not None):
+        if (self.current_iter == 0) and (write_ncmc):
             self.ncmc_reporter = app.dcdreporter.DCDReporter(self.ncmc_outfile, 1) 
             self.nc_sim.reporters.append(self.ncmc_reporter)
         for nc_step in range(self.nstepsNC):
@@ -233,7 +233,7 @@ class Simulation(object):
                 self.current_stepNC = int(nc_step)
                 # Calculate Work/Energies Before Step
                 work_initial = self.getWorkInfo(self.nc_integrator, self.work_keys)
-                if self.write_ncmc and (nc_step+1) % self.write_ncmc == 0:
+                if write_ncmc and (nc_step+1) % write_ncmc == 0:
                     self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
                      
 
@@ -244,7 +244,7 @@ class Simulation(object):
 
                     #Do move
                     self.model, self.nc_context = self.mover.moves['method'](model=self.model, nc_context=self.nc_context)
-                    if self.write_ncmc and (nc_step+1) % self.write_ncmc == 0:
+                    if write_ncmc and (nc_step+1) % write_ncmc == 0:
                         self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
 
 
@@ -303,7 +303,7 @@ class Simulation(object):
         for n in range(self.nIter):
             self.current_iter = int(n)
             self.setStateConditions()
-            self.simulateNCMC(verbose=self.verbose)
+            self.simulateNCMC(verbose=self.verbose, write_ncmc=self.write_ncmc)
             self.chooseMove()
             self.simulateMD()
 

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -233,8 +233,6 @@ class Simulation(object):
                 self.current_stepNC = int(nc_step)
                 # Calculate Work/Energies Before Step
                 work_initial = self.getWorkInfo(self.nc_integrator, self.work_keys)
-                if write_ncmc and (nc_step+1) % write_ncmc == 0:
-                    self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
                      
 
                 # Attempt NCMC Move
@@ -250,6 +248,8 @@ class Simulation(object):
 
                 # Do 1 NCMC step
                 self.nc_integrator.step(1)
+                if write_ncmc and (nc_step+1) % write_ncmc == 0:
+                    self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
 
                 # Calculate Work/Energies After Step.
                 work_final = self.getWorkInfo(self.nc_integrator, self.work_keys)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -46,6 +46,7 @@ class Simulation(object):
         self.md_sim = simulations.md
         self.alch_sim = simulations.alch
         self.nc_context = simulations.nc.context
+        self.nc_sim = simulations.nc
         self.nc_integrator = simulations.nc.context._integrator
         self.model = model
         self.mover = mover
@@ -276,6 +277,8 @@ class Simulation(object):
         Perform NCMC simulation, perform proposed move, accepts/rejects move,
         then performs the MD simulation from the NCMC state.
         """
+        reporter = app.statedatareporter.StateDataReporter('test.csv', step=True)
+        self.nc_sim.reporters.append(reporter)
         #set inital conditions
         self.setStateConditions()
         for n in range(self.nIter):


### PR DESCRIPTION
This PR adds the following funcitonality:
Adds support for a write_ncmc option for the opt dictionary. The value of write_ncmc is an integer and specifies at what interval the frames are output, so everytime `ncsteps % write_ncmc == 0` a frame is output. This also automatically outputs a frame when a move is performed. 
A openmm dcdreporter outputs the frame to ncmc_outfile, which can also be specifed in opt (the default value is ncmc_output.dcd'). 
Addresses #71