### PR TITLE
[WIP] Revert to using old alchemy package

### DIFF
--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -57,11 +57,16 @@ class SimulationFactory(object):
         atom_indices : list
             Atom indicies of the move.
         """
-        import logging
-        logging.getLogger("openmmtools.alchemy").setLevel(logging.ERROR)
-        factory = alchemy.AbsoluteAlchemicalFactory()
-        alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices)
-        alch_system = factory.create_alchemical_system(system, alch_region)
+        #TODO: add back in when alchemy issue is resolved
+        #import logging
+        #logging.getLogger("openmmtools.alchemy").setLevel(logging.ERROR)
+        #factory = alchemy.AbsoluteAlchemicalFactory()
+        #alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices)
+        #alch_system = factory.create_alchemical_system(system, alch_region)
+
+        from alchemy import AbsoluteAlchemicalFactory                               
+        factory = AbsoluteAlchemicalFactory(system, ligand_atoms=atom_indices, annihilate_sterics=True, annihilate_electrostatics=True)
+        alch_system = factory.createPerturbedSystem()                         
         return alch_system
 
     def generateSystem(self, structure, nonbondedMethod='PME', nonbondedCutoff=10,

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
-    - alchemy
+   # - alchemy
 
   run:
     - python
@@ -27,7 +27,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
-    - alchemy
+   # - alchemy
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
-   # - alchemy
+    - alchemy
 
   run:
     - python
@@ -27,7 +27,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
-   # - alchemy
+    - alchemy
 
 test:
   requires:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
+    - alchemy
 
   run:
     - python
@@ -26,6 +27,7 @@ requirements:
     - openmmtools
     - mdtraj >=1.8.0
     - openmm >=7.1.0rc1
+    - alchemy
 
 test:
   requires:


### PR DESCRIPTION
Temporarily switch to old `alchemy` package while we sort out what's causing drastic differences in protocol work between that package and `openmmtools.alchemy`.