### PR TITLE
Features to boost move acceptance and general code cleanup.

### DIFF
--- a/blues/example.py
+++ b/blues/example.py
@@ -41,6 +41,7 @@ def init_logger():
 def runNCMC(platform_name, nstepsNC, nprop, outfname):
 
     logger = init_logger()
+
     #Generate the ParmEd Structure
     prmtop = utils.get_data_filename('blues', 'tests/data/eqToluene.prmtop')#
     inpcrd = utils.get_data_filename('blues', 'tests/data/eqToluene.inpcrd')
@@ -52,10 +53,11 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
             'nIter' : 100, 'nstepsNC' : nstepsNC, 'nstepsMD' : 5000, 'nprop' : nprop,
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10,
             'constraints': 'HBonds', 'freeze_distance' : 5.0,
-            'trajectory_interval' : 100, 'reporter_interval' : 100,
+            'trajectory_interval' : 1000, 'reporter_interval' : 1000,
             'ncmc_traj' : None, 'write_move' : True,
             'platform' : platform_name,
             'verbose' : False}
+            
     for k,v in opt.items():
         logger.debug('Options: {} = {}'.format(k,v))
 

--- a/blues/example.py
+++ b/blues/example.py
@@ -32,11 +32,11 @@ def runNCMC(platform_name, nstepsNC, outfname):
 
     #Define some options
     opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
-            'nIter' : 250, 'nstepsNC' : nstepsNC, 'nstepsMD' : 10000,
+            'nIter' : 100, 'nstepsNC' : nstepsNC, 'nstepsMD' : 10000,
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
             'trajectory_interval' : 1000, 'reporter_interval' : 5000, 'write_ncmc' : False,
             'platform' : platform_name, 'zero_list' : site_idx,
-            'verbose' : True }
+            'verbose' : False }
     print('Options:')
     for k,v in opt.items():
         print('\t', k,v)
@@ -66,16 +66,17 @@ parser.add_option('-n','--ncmc', dest='nstepsNC', type='int', default=5000,
                   help='number of NCMC steps')
 parser.add_option('-o','--output', dest='outfname', type='str', default="blues",
                   help='Filename for output DCD')
+(options, args) = parser.parse_args()
 
 platformNames = [openmm.Platform.getPlatform(i).getName() for i in range(openmm.Platform.getNumPlatforms())]
 
-if 'OpenCL' in platformNames:
-    runNCMC('OpenCL')
-elif 'CUDA' in platformNames:
-    runNCMC('CUDA')
+if 'CUDA' in platformNames:
+    runNCMC('CUDA', options.nstepsNC, options.outfname)
+elif 'OpenCL' in platformNames:
+    runNCMC('OpenCL',options.nstepsNC, options.outfname)
 else:
     if options.force:
-        runNCMC('CPU')
+        runNCMC('CPU', options.nstepsNC, options.outfname)
     else:
         print('WARNING: Could not find a valid CUDA/OpenCL platform. BLUES is not recommended on CPUs.')
         print("To run on CPU: 'python blues/example.py -f'")

--- a/blues/example.py
+++ b/blues/example.py
@@ -48,7 +48,7 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10,
             'constraints': 'HBonds', 'freeze_distance' : 5.0,
             'trajectory_interval' : 100, 'reporter_interval' : 100,
-            'write_ncmc' : False, 'write_move' : True,
+            'ncmc_traj' : None, 'write_move' : True,
             'platform' : platform_name,
             'verbose' : False}
     for k,v in opt.items():

--- a/blues/example.py
+++ b/blues/example.py
@@ -32,9 +32,10 @@ def runNCMC(platform_name, nstepsNC, outfname):
 
     #Define some options
     opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
-            'nIter' : 100, 'nstepsNC' : nstepsNC, 'nstepsMD' : 10000,
+            'nIter' : 100, 'nstepsNC' : nstepsNC, 'nstepsMD' : 5000, 'nprop' : 5,
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
-            'trajectory_interval' : 1000, 'reporter_interval' : 5000, 'write_ncmc' : False,
+            'trajectory_interval' : 1000, 'reporter_interval' : 5000,
+            'write_ncmc' : False, 'write_move' : True,
             'platform' : platform_name, 'zero_list' : site_idx,
             'verbose' : False }
     print('Options:')

--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -170,10 +170,9 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
     def reset(self):
         self.setGlobalVariableByName("step", 0)
         self.setGlobalVariableByName("lambda", 0.0)
-#        self.setGlobalVariableByName("total_work", 0.0)
+        self.setGlobalVariableByName("lambda_step", 0.0)
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)
         self.setGlobalVariableByName("perturbed_pe", 0.0)
         self.setGlobalVariableByName("unperturbed_pe", 0.0)
-

--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -169,9 +169,6 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
             self.beginIfBlock("lambda <= prop_lambda_max")
 
             self.beginWhileBlock("prop < nprop")
-#            self.beginIfBlock("( lambda >= prop_lambda_min ) and ( lambda < prop_lambda_max )")
-
-#            self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
             self.addComputeGlobal("prop", "prop + 1")
 
             super(AlchemicalNonequilibriumLangevinIntegrator, self)._add_integrator_steps()
@@ -191,7 +188,6 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
         TODO: Extend this to be able to handle force groups?
         """
         # Store initial potential energy
-        print('aaaaaa')
         self.beginIfBlock("prop = 1")
         self.addComputeGlobal("debug", "debug + 1")
         self.addComputeGlobal("Eold", "energy")
@@ -218,7 +214,6 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
     def reset(self):
         self.setGlobalVariableByName("step", 0)
         self.setGlobalVariableByName("lambda", 0.0)
-#        self.setGlobalVariableByName("total_work", 0.0)
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)

--- a/blues/integrators.py
+++ b/blues/integrators.py
@@ -68,6 +68,9 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
                  measure_shadow_work=False,
                  measure_heat=True,
                  nsteps_neq=100,
+                 nprop=1,
+                 prop_lambda_min=0.2,
+                 prop_lambda_max=0.8,
                  *args, **kwargs):
         """
         Parameters
@@ -113,6 +116,15 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
         self.addGlobalVariable("perturbed_pe", 0)
         self.addGlobalVariable("unperturbed_pe", 0)
         self.addGlobalVariable("first_step", 0)
+        self.addGlobalVariable("nprop", nprop)
+        self.addGlobalVariable("prop", 1)
+        self.addGlobalVariable("prop_lambda_min", prop_lambda_min)
+        self.addGlobalVariable("prop_lambda_max", prop_lambda_max)
+        self._registered_step_types['H'] = (self._add_alchemical_perturbation_step, False)
+        self.addGlobalVariable("debug", 0)
+
+
+
         try:
             self.getGlobalVariableByName("shadow_work")
         except:
@@ -149,16 +161,52 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
             self.addComputeGlobal("first_step", "1")
             self.addComputeGlobal("unperturbed_pe", "energy")
             self.endBlock()
-
+            #initial iteration
             self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
+            super(AlchemicalNonequilibriumLangevinIntegrator, self)._add_integrator_steps()
+            #if more propogation steps are requested
+            self.beginIfBlock("lambda > prop_lambda_min")
+            self.beginIfBlock("lambda <= prop_lambda_max")
+
+            self.beginWhileBlock("prop < nprop")
+#            self.beginIfBlock("( lambda >= prop_lambda_min ) and ( lambda < prop_lambda_max )")
+
+#            self.addComputeGlobal("protocol_work", "protocol_work + (perturbed_pe - unperturbed_pe)")
+            self.addComputeGlobal("prop", "prop + 1")
 
             super(AlchemicalNonequilibriumLangevinIntegrator, self)._add_integrator_steps()
-
+            self.endBlock()
+            self.endBlock()
+            self.endBlock()
+            #ending variables to reset
             self.addComputeGlobal("unperturbed_pe", "energy")
             self.addComputeGlobal("step", "step + 1")
+            self.addComputeGlobal("prop", "1")
 
             self.endBlock()
 
+    def _add_alchemical_perturbation_step(self):
+        """
+        Add alchemical perturbation step, accumulating protocol work.
+        TODO: Extend this to be able to handle force groups?
+        """
+        # Store initial potential energy
+        print('aaaaaa')
+        self.beginIfBlock("prop = 1")
+        self.addComputeGlobal("debug", "debug + 1")
+        self.addComputeGlobal("Eold", "energy")
+
+        # Update lambda and increment that tracks updates.
+        self.addComputeGlobal('lambda', '(lambda_step+1)/n_lambda_steps')
+        self.addComputeGlobal('lambda_step', 'lambda_step + 1')
+
+        # Update all slaved alchemical parameters
+        self._add_update_alchemical_parameters_step()
+
+        # Accumulate protocol work
+        self.addComputeGlobal("Enew", "energy")
+        self.addComputeGlobal("protocol_work", "protocol_work + (Enew-Eold)")
+        self.endBlock()
 
     def getLogAcceptanceProbability(self, context):
         #TODO remove context from arguments if/once ncmc_switching is changed
@@ -170,9 +218,11 @@ class AlchemicalExternalLangevinIntegrator(AlchemicalNonequilibriumLangevinInteg
     def reset(self):
         self.setGlobalVariableByName("step", 0)
         self.setGlobalVariableByName("lambda", 0.0)
-        self.setGlobalVariableByName("lambda_step", 0.0)
+#        self.setGlobalVariableByName("total_work", 0.0)
         self.setGlobalVariableByName("protocol_work", 0.0)
         self.setGlobalVariableByName("shadow_work", 0.0)
         self.setGlobalVariableByName("first_step", 0)
         self.setGlobalVariableByName("perturbed_pe", 0.0)
         self.setGlobalVariableByName("unperturbed_pe", 0.0)
+        self.setGlobalVariableByName("prop", 1)
+        super(AlchemicalExternalLangevinIntegrator, self).reset()

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -481,7 +481,7 @@ class Simulation(object):
         # END OF NITER
         self.accept_ratio = self.accept/float(nIter)
         self.logger.info('Acceptance Ratio: %s' % self.accept_ratio)
-        self.logger.info('nIter: %s ' % self.nIter)
+        self.logger.info('nIter: %s ' % nIter)
 
     def simulateMC(self):
         """Function that performs the MC simulation."""

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -74,7 +74,7 @@ class SimulationFactory(object):
         alch_system = factory.create_alchemical_system(system, alch_region)
 
         if 'zero_list' in opt:
-            print('Zeroing masses of atoms:', len(opt['zero_list']))
+            print('Zeroing masses of %s atoms:' % len(opt['zero_list']))
             alch_system = self.zero_allother_masses(alch_system, opt['zero_list'])
         else:
             pass
@@ -506,7 +506,7 @@ class Simulation(object):
             self.current_iter = int(n)
             self.setStateConditions()
             self.simulateNCMC(verbose=self.verbose, write_ncmc=self.write_ncmc)
-            self.acceptRejectNCMC(write_move=False)
+            self.acceptRejectNCMC(write_move=True)
             self.simulateMD()
 
         # END OF NITER

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -74,7 +74,7 @@ class SimulationFactory(object):
         alch_system = factory.create_alchemical_system(system, alch_region)
 
         if 'zero_list' in opt:
-            print('Zeroing masses of %s atoms:' % len(opt['zero_list']))
+            print('Zeroing masses of %s atoms' % len(opt['zero_list']))
             alch_system = self.zero_allother_masses(alch_system, opt['zero_list'])
         else:
             pass
@@ -212,7 +212,7 @@ class Simulation(object):
         self.accept = 0
         self.reject = 0
         self.accept_ratio = 0
-
+        self.opt = opt
         self.nIter = int(opt['nIter'])
         #if nstepsNC not specified, set it to 0
         #will be caught if NCMC simulation is run
@@ -374,7 +374,7 @@ class Simulation(object):
                                    xyz=state.getPositions())
 
         structure.save(outfname,overwrite=True)
-        print('Saving Frame to', outfname)
+        print('\tSaving Frame to', outfname)
 
     def acceptRejectNCMC(self, write_move=False):
         """Function that chooses to accept or reject the proposed move.
@@ -443,9 +443,8 @@ class Simulation(object):
                 self.nc_integrator.step(1)
 
                 if nc_step % reporter_interval == 0:
-                    if verbose:
-                        workinfo = self.getWorkInfo(self.nc_integrator, ['step','lambda','lambda_step', 'protocol_work'])
-                        print('\tStep = {step}  Lambda = {lambda}  Work = {protocol_work} Lambda_step = {lambda_step}'.format(**workinfo))
+                    workinfo = self.getWorkInfo(self.nc_integrator, ['step','lambda','lambda_step', 'protocol_work'])
+                    print('\tStep = {step}  Lambda = {lambda}  Work = {protocol_work} Lambda_step = {lambda_step}'.format(**workinfo))
                     if write_ncmc:
                         self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
 
@@ -505,8 +504,8 @@ class Simulation(object):
         for n in range(self.nIter):
             self.current_iter = int(n)
             self.setStateConditions()
-            self.simulateNCMC(verbose=self.verbose, write_ncmc=self.write_ncmc)
-            self.acceptRejectNCMC(write_move=True)
+            self.simulateNCMC(verbose=self.verbose, write_ncmc=self.write_ncmc, nprop=self.opt['nprop'])
+            self.acceptRejectNCMC(write_move=self.opt['write_move'])
             self.simulateMD()
 
         # END OF NITER

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -57,7 +57,7 @@ class SimulationFactory(object):
                 system.setParticleMass(index, 0*unit.daltons)
         return system
 
-    def generateAlchSystem(self, system, atom_indices, freeze_distance, **opt):
+    def generateAlchSystem(self, system, atom_indices, freeze_distance=0, **opt):
         """Returns the OpenMM System for alchemical perturbations.
 
         Parameters

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -353,7 +353,7 @@ class Simulation(object):
         structure.save(outfname,overwrite=True)
         self.logger.info('\tSaving Frame to: %s' % outfname)
 
-    def acceptRejectNCMC(self, temperature, write_move=False, **opt):
+    def acceptRejectNCMC(self, temperature=300, write_move=False, **opt):
         """Function that chooses to accept or reject the proposed move.
         """
         md_state0 = self.current_state['md']['state0']
@@ -493,7 +493,7 @@ class Simulation(object):
         md_state1 = self.getStateInfo(new_context, self.state_keys)
         self.setSimState('md', 'state1', md_state1)
 
-    def acceptRejectMC(self, temperature, **opt):
+    def acceptRejectMC(self, temperature=300, **opt):
         """Function that chooses to accept or reject the proposed move.
         """
         md_state0 = self.current_state['md']['state0']
@@ -503,13 +503,13 @@ class Simulation(object):
 
         if log_mc > randnum:
             self.accept += 1
-            self.logger.info('MC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_mc, randnum) )
+            self.logger.info('MC MOVE ACCEPTED: log_mc {} > randnum {}'.format(log_mc, randnum) )
             self.md_sim.context.setPositions(md_state1['positions'])
         else:
             self.reject += 1
-            self.logger.info('MC MOVE REJECTED: log_ncmc {} < {}'.format(log_mc, randnum) )
+            self.logger.info('MC MOVE REJECTED: log_mc {} < {}'.format(log_mc, randnum) )
             self.md_sim.context.setPositions(md_state0['positions'])
-
+        self.log_mc = log_mc
         self.md_sim.context.setVelocitiesToTemperature(temperature)
 
     def runMC(self, nIter=100):
@@ -525,5 +525,5 @@ class Simulation(object):
             for i in range(self.mc_per_iter):
                 self.setStateConditions()
                 self.simulateMC()
-                self.acceptRejectMC()
-            self.simulateMD()
+                self.acceptRejectMC(**self.opt)
+            self.simulateMD(**self.opt)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -361,7 +361,7 @@ class Simulation(object):
         structure.save(outfname,overwrite=True)
         print('Saving Frame to', outfname)
 
-    def acceptRejectNCMC(self):
+    def acceptRejectNCMC(self, write_move=False):
         """Function that chooses to accept or reject the proposed move.
         """
         md_state0 = self.current_state['md']['state0']
@@ -383,6 +383,8 @@ class Simulation(object):
             self.accept += 1
             print('NCMC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_ncmc, randnum) )
             self.md_sim.context.setPositions(nc_state1['positions'])
+            if write_move:
+                self.writeFrame(self.md_sim, 'acc-it%s-nc%s.pdb' %(self.current_iter,self.nstepsNC))
         else:
             self.reject += 1
             print('NCMC MOVE REJECTED: log_ncmc {} < {}'.format(log_ncmc, randnum) )
@@ -480,7 +482,7 @@ class Simulation(object):
             self.current_iter = int(n)
             self.setStateConditions()
             self.simulateNCMC(verbose=self.verbose, write_ncmc=self.write_ncmc)
-            self.acceptRejectNCMC()
+            self.acceptRejectNCMC(write_move=False)
             self.simulateMD()
 
         # END OF NITER

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -173,7 +173,7 @@ class SimulationFactory(object):
     def createSimulationSet(self):
         """Function used to generate the 3 OpenMM Simulation objects."""
         self.system = self.generateSystem(self.structure, **self.opt)
-        self.alch_system = self.generateAlchSystem(self.system, self.atom_indices)
+        self.alch_system = self.generateAlchSystem(self.system, self.atom_indices, **self.opt)
 
         self.md = self.generateSimFromStruct(self.structure, self.system, **self.opt)
         self.alch = self.generateSimFromStruct(self.structure, self.system,  **self.opt)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -292,9 +292,9 @@ class Simulation(object):
         self.setSimState('nc', 'state0', nc_state0)
 
     def _getSimulationInfo(self):
-        partNC = 0.2 / (1/ self.opt['nstepsNC'])
-        propNC = (partNC * 3) * self.opt['nprop']
-        totalNC = (partNC * 2) + propNC
+        partNC = 0.2 / (1.0/ self.opt['nstepsNC'])
+        propNC = (partNC * 3.0) * self.opt['nprop']
+        totalNC = (partNC * 2.0) + propNC
         timeNC = totalNC * self.opt['dt']
         timeMD = self.opt['nstepsMD'] * self.opt['dt']
         timetraj = self.opt['trajectory_interval'] * self.opt['dt']

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -228,7 +228,7 @@ class Simulation(object):
 
         #Get Lambda step parameters for extra propagation
         self._getAlchStepParameters()
-        self._getSimulationInfo()
+
         self.current_iter = 0
         self.current_state = { 'md'   : { 'state0' : {}, 'state1' : {} },
                                'nc'   : { 'state0' : {}, 'state1' : {} },
@@ -502,6 +502,7 @@ class Simulation(object):
         then performs the MD simulation from the NCMC state.
         """
         logger.info('Running %i BLUES iterations...' % (nIter))
+        self._getSimulationInfo()
         #set inital conditions
         self.setStateConditions()
         for n in range(int(nIter)):

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -47,7 +47,17 @@ class SimulationFactory(object):
         self.nc  = None
 
         self.opt = opt
-    def generateAlchSystem(self, system, atom_indices):
+
+    def zero_allother_masses(self, system, indexlist):
+        num_atoms = system.getNumParticles()
+        for index in range(num_atoms):
+            if index in indexlist:
+                pass
+            else:
+                system.setParticleMass(index, 0*unit.daltons)
+        return system
+
+    def generateAlchSystem(self, system, atom_indices, **opt):
         """Returns the OpenMM System for alchemical perturbations.
 
         Parameters
@@ -62,6 +72,13 @@ class SimulationFactory(object):
         factory = alchemy.AbsoluteAlchemicalFactory(disable_alchemical_dispersion_correction=True)
         alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices)
         alch_system = factory.create_alchemical_system(system, alch_region)
+
+        if 'zero_list' in opt:
+            print('Zeroing masses of atoms:', len(opt['zero_list']))
+            alch_system = self.zero_allother_masses(alch_system, opt['zero_list'])
+        else:
+            pass
+
         return alch_system
 
     def generateSystem(self, structure, nonbondedMethod='PME', nonbondedCutoff=10,
@@ -515,4 +532,3 @@ class Simulation(object):
                 self.simulateMC()
                 self.acceptRejectMC()
             self.simulateMD()
-

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -13,6 +13,7 @@ import sys
 from openmmtools import alchemy
 from blues.integrators import AlchemicalExternalLangevinIntegrator
 import logging
+logger = logging.getLogger(__name__)
 
 class SimulationFactory(object):
     """SimulationFactory is used to generate the 3 required OpenMM Simulation
@@ -33,7 +34,7 @@ class SimulationFactory(object):
         nonbondedMethod='PME', nonbondedCutoff=10, constraints='HBonds',
         trajectory_interval=1000, reporter_interval=1000, platform=None,
         verbose=False"""
-        self.logger = logging.getLogger(__name__)
+        #logger = opt['Logger'] #logging.getLogger(__name__)
         #Structure of entire system
         self.structure = structure
         #Atom indicies from move_engine
@@ -57,7 +58,9 @@ class SimulationFactory(object):
                 system.setParticleMass(index, 0*unit.daltons)
         return system
 
-    def generateAlchSystem(self, system, atom_indices, freeze_distance=0, **opt):
+    def generateAlchSystem(self, system, atom_indices,
+                            freeze_distance=0, freeze_center='LIG', freeze_solvent='HOH,NA,CL',
+                            **opt):
         """Returns the OpenMM System for alchemical perturbations.
 
         Parameters
@@ -66,6 +69,12 @@ class SimulationFactory(object):
             The OpenMM System object corresponding to the reference system.
         atom_indices : list
             Atom indicies of the move.
+        freeze_center : str
+            AmberMask selection for the center in which to select atoms for zeroing their masses. Default: LIG
+        freeze_distance : float
+            Distance (angstroms) to select atoms for retaining their masses. Atoms outside the set distance will have their masses set to 0.0. Default: 5.0
+        freeze_solvent : str
+            AmberMask selection in which to select solvent atoms for zeroing their masses. Default: HOH,NA,CL
         """
         logging.getLogger("openmmtools.alchemy").setLevel(logging.ERROR)
         factory = alchemy.AbsoluteAlchemicalFactory(disable_alchemical_dispersion_correction=True)
@@ -75,9 +84,9 @@ class SimulationFactory(object):
 
         if freeze_distance:
             #Atom selection for zeroing protein atom masses
-            mask = parmed.amber.AmberMask(self.structure,"(:LIG<:%f)&!(:HOH,NA,CL)" % freeze_distance )
+            mask = parmed.amber.AmberMask(self.structure,"(:%s<:%f)&!(:%s)" % (freeze_center,freeze_distance,freeze_solvent))
             site_idx = [i for i in mask.Selected()]
-            self.logger.info('Zeroing mass of %s protein atoms %.1f Angstroms from LIG' % (len(site_idx), freeze_distance))
+            logger.info('Zeroing mass of %s atoms %.1f Angstroms from LIG' % (len(site_idx), freeze_distance))
             alch_system = self._zero_allother_masses(alch_system, site_idx)
         else:
             pass
@@ -85,7 +94,7 @@ class SimulationFactory(object):
         return alch_system
 
     def generateSystem(self, structure, nonbondedMethod='PME', nonbondedCutoff=10,
-                       constraints='HBonds', **opt):
+                       constraints='HBonds', hydrogenMass=None, **opt):
         """Returns the OpenMM System for the reference system.
 
         Parameters
@@ -94,15 +103,21 @@ class SimulationFactory(object):
             ParmEd Structure object of the entire system to be simulated.
         opt : optional parameters (i.e. cutoffs/constraints)
         """
+        if hydrogenMass:
+            logger.info('HMR Settings: \n\ttimestep: {} \n\tconstraints: {} \n\tHydrogenMass: {}*unit.dalton'.format(opt['dt'], constraints, hydrogenMass))
+            hydrogenMass = hydrogenMass*unit.dalton
+        else:
+            hydrogenMass = None
         system = structure.createSystem(nonbondedMethod=eval("app.%s" % nonbondedMethod),
                             nonbondedCutoff=nonbondedCutoff*unit.angstroms,
-                            constraints=eval("app.%s" % constraints) )
+                            constraints=eval("app.%s" % constraints),
+                            hydrogenMass=hydrogenMass)
         return system
 
     def generateSimFromStruct(self, structure, system, nIter, nstepsNC, nstepsMD,
                              temperature=300, dt=0.002, friction=1,
                              reporter_interval=1000,
-                             ncmc=False, platform=None,
+                             ncmc=False, platform=None, verbose=False,
                              **opt):
         """Used to generate the OpenMM Simulation objects given a ParmEd Structure.
 
@@ -142,16 +157,16 @@ class SimulationFactory(object):
             #prop = dict(DeviceIndex='2') # For local testing with multi-GPU Mac.
             simulation = app.Simulation(structure.topology, system, integrator, platform)#, prop)
 
-        if self.logger.isEnabledFor(logging.DEBUG):
+        if verbose:
             # OpenMM platform information
             mmver = openmm.version.version
             mmplat = simulation.context.getPlatform()
-            self.logger.debug('OpenMM({}) simulation generated for {} platform'.format(mmver, mmplat.getName()))
+            logger.debug('OpenMM({}) simulation generated for {} platform'.format(mmver, mmplat.getName()))
 
             # Platform properties
             for prop in mmplat.getPropertyNames():
                 val = mmplat.getPropertyValue(simulation.context, prop)
-                self.logger.debug('PlatformProperties: {} - {}'.format(prop,val))
+                logger.debug('PlatformProperties: {} - {}'.format(prop,val))
 
         # Set initial positions/velocities
         # Will get overwritten from saved State.
@@ -191,7 +206,7 @@ class Simulation(object):
             MoveProposal object which contains the dict of moves performed
             in the NCMC simulation.
         """
-        self.logger = logging.getLogger(__name__)
+        #logger = opt['Logger']#logging.getLogger(__name__)
         self.opt = opt
         self.md_sim = simulations.md
         self.alch_sim = simulations.alch
@@ -213,7 +228,7 @@ class Simulation(object):
 
         #Get Lambda step parameters for extra propagation
         self._getAlchStepParameters()
-
+        self._getSimulationInfo()
         self.current_iter = 0
         self.current_state = { 'md'   : { 'state0' : {}, 'state1' : {} },
                                'nc'   : { 'state0' : {}, 'state1' : {} },
@@ -276,18 +291,40 @@ class Simulation(object):
         self.setSimState('md', 'state0', md_state0)
         self.setSimState('nc', 'state0', nc_state0)
 
+    def _getSimulationInfo(self):
+        partNC = 0.2 / (1/ self.opt['nstepsNC'])
+        propNC = (partNC * 3) * self.opt['nprop']
+        totalNC = (partNC * 2) + propNC
+        timeNC = totalNC * self.opt['dt']
+        timeMD = self.opt['nstepsMD'] * self.opt['dt']
+        timetraj = self.opt['trajectory_interval'] * self.opt['dt']
+        totaltime = (timeNC + timeMD) * self.opt['nIter']
+
+        logger.info('Iterations = %s' % self.opt['nIter'])
+        logger.info('Timestep = %s ps' % self.opt['dt'])
+        logger.info('NCMC Steps = %s' % self.opt['nstepsNC'])
+        logger.info('\tnprop = %s' % self.opt['nprop'])
+        logger.info('\tLambda: 0.0 -> 0.2 = %s NCMC Steps' % partNC)
+        logger.info('\tLambda: 0.2 -> 0.8 = %s NCMC Steps' % propNC)
+        logger.info('\tLambda: 0.8 -> 1.0 = %s NCMC Steps' % partNC)
+        logger.info('\t%s NCMC Steps/iter' % totalNC)
+        logger.info('\t%s NCMC ps/iter' % timeNC)
+        logger.info('MD Steps = %s' % self.opt['nstepsMD'])
+        logger.info('\t%s MD ps/iter' % timeMD)
+        logger.info('\tTrajectory Interval = %s ps' % timetraj)
+        logger.info('Total Simulation Time = %s ps' % totaltime)
+        logger.info('\tTotal NCMC time = %s ps' % (int(timeNC) * int(self.opt['nIter'])))
+        logger.info('\tTotal MD time = %s ps' % (int(timeMD) * int(self.opt['nIter'])))
+
     def _getAlchStepParameters(self):
         initial_lambda = self.nc_integrator.getGlobalVariableByName('lambda')
-        initial_step = self.nc_integrator.getGlobalVariableByName('step')
         initial_lambda_step = self.nc_integrator.getGlobalVariableByName('lambda_step')
         self.nc_integrator.step(1)
         final_lambda = self.nc_integrator.getGlobalVariableByName('lambda')
-        final_step = self.nc_integrator.getGlobalVariableByName('step')
         final_lambda_step = self.nc_integrator.getGlobalVariableByName('lambda_step')
         self.nc_integrator.reset()
 
         self.d_lambda = final_lambda - initial_lambda
-        self.d_step = final_step - initial_step
         self.d_lambda_step = final_lambda_step - initial_lambda_step
 
     def getStateInfo(self, context, parameters):
@@ -350,7 +387,7 @@ class Simulation(object):
                                    xyz=state.getPositions())
 
         structure.save(outfname,overwrite=True)
-        self.logger.info('\tSaving Frame to: %s' % outfname)
+        logger.info('\tSaving Frame to: %s' % outfname)
 
     def acceptRejectNCMC(self, temperature=300, write_move=False, **opt):
         """Function that chooses to accept or reject the proposed move.
@@ -372,23 +409,24 @@ class Simulation(object):
 
         if log_ncmc > randnum:
             self.accept += 1
-            self.logger.info('NCMC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_ncmc, randnum) )
+            logger.info('NCMC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_ncmc, randnum) )
             self.md_sim.context.setPositions(nc_state1['positions'])
             if write_move:
-                self.writeFrame(self.md_sim, 'acc-it%s.pdb' %(self.current_iter))
+            	self.writeFrame(self.md_sim, '{}acc-it{}.pdb'.format(self.opt['outfname'],self.current_iter))
+
         else:
             self.reject += 1
-            self.logger.info('NCMC MOVE REJECTED: log_ncmc {} < {}'.format(log_ncmc, randnum) )
+            logger.info('NCMC MOVE REJECTED: log_ncmc {} < {}'.format(log_ncmc, randnum) )
             self.nc_context.setPositions(md_state0['positions'])
 
         self.nc_integrator.reset()
         self.md_sim.context.setVelocitiesToTemperature(temperature)
 
     def simulateNCMC(self, nstepsNC=5000, nprop=5, ncmc_traj=None,
-                    reporter_interval=1000, **opt):
+                    reporter_interval=1000, verbose=False, **opt):
         """Function that performs the NCMC simulation."""
 
-        self.logger.info('[Iter %i] Starting NCMC Simulation with %i NCMC steps...' % (self.current_iter, nstepsNC))
+        logger.info('[NCMC-Iter %i] Advancing %i NCMC steps...' % (self.current_iter, nstepsNC))
 
         #choose a move to be performed according to move probabilities
         #TODO: will have to change to work with multiple alch regions
@@ -399,16 +437,16 @@ class Simulation(object):
                 #to ensure protocol is symmetric
                 if self.movestep == nc_step:
                     #Do move
-                    self.logger.info('Step = %s Performing NCMC move...' % nc_step)
+                    logger.info('Step = %s Performing NCMC move...' % nc_step)
                     self.nc_context = self.move_engine.runEngine(self.nc_context)
 
                 # Add extra propagation steps
                 if nprop > 1:
                     current_lambda = self.nc_integrator.getGlobalVariableByName('lambda')
-                    if current_lambda >= 0.2 and current_lambda <= 0.8:
+                    if 0.2 < current_lambda <= 0.8:
                         for n in range(int(nprop)):
                             self.nc_integrator.setGlobalVariableByName('lambda', self.nc_integrator.getGlobalVariableByName('lambda') - self.d_lambda)
-                            self.nc_integrator.setGlobalVariableByName('step', self.nc_integrator.getGlobalVariableByName('step') - self.d_step)
+                            self.nc_integrator.setGlobalVariableByName('step', self.nc_integrator.getGlobalVariableByName('step') - 1.0)
                             self.nc_integrator.setGlobalVariableByName('lambda_step', self.nc_integrator.getGlobalVariableByName('lambda_step') - self.d_lambda_step)
                             self.nc_integrator.step(1)
 
@@ -418,19 +456,19 @@ class Simulation(object):
                 # Print out NCMC info to show progress.
                 if nc_step % reporter_interval == 0:
                     workinfo = self.getWorkInfo(self.nc_integrator, ['step','lambda','lambda_step', 'protocol_work'])
-                    self.logger.info('Step = {step}  Lambda = {lambda}  Work = {protocol_work} Lambda_step = {lambda_step}'.format(**workinfo))
+                    logger.info('Step = {step}  Lambda = {lambda}  Work = {protocol_work} Lambda_step = {lambda_step}'.format(**workinfo))
 
 
                 ###DEBUG options at every NCMC step
-                if self.logger.isEnabledFor(logging.DEBUG):
+                if verbose:
                     # Print energies at every step
                     work = self.getWorkInfo(self.nc_integrator, self.work_keys)
-                    self.logger.debug('%s' % work)
+                    logger.debug('%s' % work)
                 if ncmc_traj:
                     self.ncmc_reporter.report(self.nc_sim, self.nc_sim.context.getState(getPositions=True, getVelocities=True))
 
             except Exception as e:
-                self.logger.error(e)
+                logger.error(e)
                 break
 
         nc_state1 = self.getStateInfo(self.nc_context, self.state_keys)
@@ -439,15 +477,15 @@ class Simulation(object):
     def simulateMD(self, nstepsMD=5000, **opt):
         """Function that performs the MD simulation."""
 
-        self.logger.info('[Iter %i] Starting MD Simulation with %i MD steps...' % (self.current_iter, nstepsMD))
+        logger.info('[MD-Iter %i] Advancing %i MD steps...' % (self.current_iter, nstepsMD))
 
         md_state0 = self.current_state['md']['state0']
         try:
             self.md_sim.step(nstepsMD)
         except Exception as e:
-            self.logger.error(e)
-            self.logger.error('potential energy before NCMC: %s' % md_state0['potential_energy'])
-            self.logger.error('kinetic energy before NCMC: %s' % md_state0['kinetic_energy'])
+            logger.error(e)
+            logger.error('potential energy before NCMC: %s' % md_state0['potential_energy'])
+            logger.error('kinetic energy before NCMC: %s' % md_state0['kinetic_energy'])
             #Write out broken frame
             self.writeFrame(self.md_sim, 'MD-fail-it%s-md%i.pdb' %(self.current_iter, self.md_sim.currentStep))
             exit()
@@ -463,7 +501,7 @@ class Simulation(object):
         Perform NCMC simulation, perform proposed move, accepts/rejects move,
         then performs the MD simulation from the NCMC state.
         """
-        self.logger.info('Running %i BLUES iterations...' % (nIter))
+        logger.info('Running %i BLUES iterations...' % (nIter))
         #set inital conditions
         self.setStateConditions()
         for n in range(int(nIter)):
@@ -475,8 +513,8 @@ class Simulation(object):
 
         # END OF NITER
         self.accept_ratio = self.accept/float(nIter)
-        self.logger.info('Acceptance Ratio: %s' % self.accept_ratio)
-        self.logger.info('nIter: %s ' % nIter)
+        logger.info('Acceptance Ratio: %s' % self.accept_ratio)
+        logger.info('nIter: %s ' % nIter)
 
     def simulateMC(self):
         """Function that performs the MC simulation."""
@@ -498,13 +536,13 @@ class Simulation(object):
 
         if log_mc > randnum:
             self.accept += 1
-            self.logger.info('MC MOVE ACCEPTED: log_mc {} > randnum {}'.format(log_mc, randnum) )
+            logger.info('MC MOVE ACCEPTED: log_mc {} > randnum {}'.format(log_mc, randnum) )
             self.md_sim.context.setPositions(md_state1['positions'])
         else:
             self.reject += 1
-            self.logger.info('MC MOVE REJECTED: log_mc {} < {}'.format(log_mc, randnum) )
+            logger.info('MC MOVE REJECTED: log_mc {} < {}'.format(log_mc, randnum) )
             self.md_sim.context.setPositions(md_state0['positions'])
-        self.log_mc = log_mc
+        logger_mc = log_mc
         self.md_sim.context.setVelocitiesToTemperature(temperature)
 
     def runMC(self, nIter=100):

--- a/blues/tests/test_blues.py
+++ b/blues/tests/test_blues.py
@@ -18,7 +18,7 @@ class BLUESTester(unittest.TestCase):
         self.inpcrd = utils.get_data_filename('blues', 'tests/data/TOL-parm.inpcrd')
         self.full_struct = parmed.load_file(self.prmtop, xyz=self.inpcrd)
         self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
-                'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2,
+                'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
                 'platform' : None,

--- a/blues/tests/test_blues.py
+++ b/blues/tests/test_blues.py
@@ -94,7 +94,7 @@ class BLUESTester(unittest.TestCase):
         self.model.calculateProperties()
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
         asim = Simulation(sims, self.mover, **self.opt)
-        asim.runNCMC()
+        asim.run(self.opt['nIter'])
 
 if __name__ == "__main__":
         unittest.main()

--- a/blues/tests/test_blues.py
+++ b/blues/tests/test_blues.py
@@ -66,10 +66,10 @@ class BLUESTester(unittest.TestCase):
     def test_simulationRun(self):
         """Tests the Simulation.runNCMC() function"""
         self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
-                'nIter' : 2, 'nstepsNC' : 100, 'nstepsMD' : 2,
+                'nIter' : 2, 'nstepsNC' : 100, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'NoCutoff', 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
-                'platform' : None,
+                'platform' : None, 'write_ncmc' : False, 'write_move' : False,
                 'verbose' : True }
 
         testsystem = testsystems.AlanineDipeptideVacuum(constraints=None)

--- a/blues/tests/test_mc.py
+++ b/blues/tests/test_mc.py
@@ -29,7 +29,7 @@ class BLUESTester(unittest.TestCase):
 
     def test_simulationRun(self):
         """Tests the Simulation.runMC() function"""
-        self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
+        self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.00002,
                 'nIter' : 2, 'nstepsNC' : 2, 'nstepsMD' : 1,
                 'nonbondedMethod' : 'NoCutoff', 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,

--- a/blues/tests/test_mc.py
+++ b/blues/tests/test_mc.py
@@ -20,7 +20,7 @@ class BLUESTester(unittest.TestCase):
         self.inpcrd = get_data_filename("data/alanine-dipeptide-explicit/alanine-dipeptide.crd")
         self.full_struct = parmed.load_file(self.prmtop, xyz=self.inpcrd)
         self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.00002,
-                'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2,
+                'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
                 'platform' : None,
@@ -30,7 +30,7 @@ class BLUESTester(unittest.TestCase):
     def test_simulationRun(self):
         """Tests the Simulation.runMC() function"""
         self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.00002,
-                'nIter' : 2, 'nstepsNC' : 2, 'nstepsMD' : 1,
+                'nIter' : 2, 'nstepsNC' : 2, 'nstepsMD' : 1, 'nprop' : 1,
                 'nonbondedMethod' : 'NoCutoff', 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
                 'platform' : None,

--- a/blues/tests/test_mc.py
+++ b/blues/tests/test_mc.py
@@ -29,7 +29,7 @@ class BLUESTester(unittest.TestCase):
 
     def test_simulationRun(self):
         """Tests the Simulation.runMC() function"""
-        self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.00002,
+        self.opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
                 'nIter' : 2, 'nstepsNC' : 2, 'nstepsMD' : 1,
                 'nonbondedMethod' : 'NoCutoff', 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
@@ -97,32 +97,32 @@ class BLUESTester(unittest.TestCase):
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
         mc_sim = Simulation(sims, self.mover, **self.opt)
         #monkeypatch to access acceptance value
-        def nacceptRejectMC(self):
+        def nacceptRejectMC(self, temperature=300, **opt):
             """Function that chooses to accept or reject the proposed move.
             """
             md_state0 = self.current_state['md']['state0']
             md_state1 = self.current_state['md']['state1']
-            log_ncmc = (md_state1['potential_energy'] - md_state0['potential_energy']) * (-1.0/self.nc_integrator.kT)
+            log_mc = (md_state1['potential_energy'] - md_state0['potential_energy']) * (-1.0/self.nc_integrator.kT)
             randnum =  math.log(np.random.random())
 
-            if log_ncmc > randnum:
+            if log_mc > randnum:
                 self.accept += 1
-                print('MC MOVE ACCEPTED: log_ncmc {} > randnum {}'.format(log_ncmc, randnum) )
+                print('MC MOVE ACCEPTED: log_mc {} > randnum {}'.format(log_mc, randnum) )
                 self.md_sim.context.setPositions(md_state1['positions'])
             else:
                 self.reject += 1
-                print('MC MOVE REJECTED: log_ncmc {} < {}'.format(log_ncmc, randnum) )
+                print('MC MOVE REJECTED: log_mc {} < {}'.format(log_mc, randnum) )
                 self.md_sim.context.setPositions(md_state0['positions'])
-            self.log_ncmc = log_ncmc
-            self.md_sim.context.setVelocitiesToTemperature(self.temperature)
+            self.log_mc = log_mc
+            self.md_sim.context.setVelocitiesToTemperature(self.opt['temperature'])
         mc_sim.acceptRejectMC = nacceptRejectMC
         nacceptRejectMC.__get__(mc_sim)
         mc_sim.acceptRejectMC = types.MethodType(nacceptRejectMC, mc_sim)
-        mc_sim.runMC()
+        mc_sim.runMC(self.opt['nIter'])
         #get log acceptance
-        print(mc_sim.log_ncmc)
+        print(mc_sim.log_mc)
         #if mc is working, should be around -24.1
-        assert mc_sim.log_ncmc <= -23.8 and mc_sim.log_ncmc >= -24.3
+        assert mc_sim.log_mc <= -23.8 and mc_sim.log_mc >= -24.3
 
 if __name__ == "__main__":
         unittest.main()

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -1,3 +1,0 @@
-
-# Build the python package
-$PYTHON setup.py install

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ def find_package_data(data_root, package_root):
 write_version_py()
 setup(
     name='blues',
-    author = "Samuel Gill, David Mobley, and others",
+    author = "Samuel C. Gill, Nathan M. Lim, David L. Mobley, and others",
     author_email='dmobley@uci.edu',
     description = ("NCMC moves in OpenMM to enhance ligand sampling"),
     long_description=read('README.md'),


### PR DESCRIPTION
In this PR, I'll be incorporating some changes that appear to boost move acceptance. 
Particularly:
- Adding extra propagation steps between lambda 0.2 -> 0.8
   - User parameter `nprop = 5` (Default). 
- Zeroing masses of atoms outside the 5.0A distance (Default) of the ligand in the alchemical system.
   - Distance for freezing atoms is now a user parameter with `freeze_distance`
   - Added option to set selection center `freeze_center` Default: 'LIG'
   - Added option to include solvent `freeze_solvent` Default: 'HOH,NA,CL'

Other changes within this PR:
- Switch print statements for `logging` module
- Made input parameters for functions in the `Simulation` class explicit 
   - Set default values but can pass the input parameters from the `opt` dictionary
- New parameter `write_move` for the `acceptRejectNCMC` function
   - Setting `write_move = True` will write the accepted move to a PDB file.
- Changed `runNCMC()` to `run()`.
   - Avoids potential confusion with function `simulateNCMC()`
- Simplified NCMC trajectory reporter
    - Replaced`write_ncmc` parameter with `ncmc_traj`
    - If a string is specified for (i.e. `ncmc_traj = ncmc_output`, it will write every NCMC step to a DCD file named `ncmc_output.dcd`
- Added a function that will print out the simulation time information [`_getSimulationInfo()`](https://github.com/MobleyLab/blues/blob/5297f12a7e612f2b1e250ecc8879b606ab7c5f50/blues/simulation.py#L294)
 