### PR TITLE
Additional Move and Simulation functionality

### DIFF
--- a/blues/moves.py
+++ b/blues/moves.py
@@ -10,7 +10,7 @@ Contributors: Nathan M. Lim, Kalistyn Burley, David L. Mobley
 """
 
 import parmed
-from simtk import unit
+from simtk import unit, openmm
 import mdtraj
 import numpy as np
 import sys, traceback
@@ -38,6 +38,25 @@ class Move(object):
         """Initialize the Move object
         Currently empy.
         """
+
+    def initializeSystem(self, system):
+        """If the system needs to be modified to perform the move
+        ex. adding a force this method is called during the start
+        of the simulation to change the system.
+
+        Parameters
+        ----------
+        system : simtk.openmm.System object
+            System to be modified.
+
+        Returns
+        -------
+        system : simtk.openmm.System object
+            The modified System object.
+        """
+        new_sys = system
+        return new_sys
+
     def beforeMove(self, context):
         return context
         

--- a/blues/moves.py
+++ b/blues/moves.py
@@ -10,7 +10,7 @@ Contributors: Nathan M. Lim, Kalistyn Burley, David L. Mobley
 """
 
 import parmed
-from simtk import unit, openmm
+from simtk import unit
 import mdtraj
 import numpy as np
 import sys, traceback
@@ -18,7 +18,7 @@ import math
 import copy
 import random
 import os
-#from openeye.oechem import *
+from openeye.oechem import *
 
 
 class Move(object):
@@ -41,8 +41,8 @@ class Move(object):
 
     def initializeSystem(self, system, integrator):
         """If the system or integrator needs to be modified to perform the move
-        ex. adding a force this method is called during the start
-        of the simulation to change the system.
+        (ex. adding a force) this method is called during the start
+        of the simulation to change the system or integrator to accomodate that.
 
         Parameters
         ----------
@@ -67,6 +67,7 @@ class Move(object):
         
     def afterMove(self, context):
         return context
+        
     def _error(self, context):
         return context
 

--- a/blues/moves.py
+++ b/blues/moves.py
@@ -18,7 +18,7 @@ import math
 import copy
 import random
 import os
-from openeye.oechem import *
+#from openeye.oechem import *
 
 
 class Move(object):
@@ -38,6 +38,17 @@ class Move(object):
         """Initialize the Move object
         Currently empy.
         """
+    def beforeMove(self, context):
+        return context
+        
+    def afterMove(self, context):
+        return context
+
+
+    def move(self, context):
+        return context
+
+
 
 class RandomLigandRotationMove(Move):
     """Move that provides methods for calculating properties on the

--- a/blues/moves.py
+++ b/blues/moves.py
@@ -269,7 +269,7 @@ class RandomLigandRotationMove(Move):
         self.positions = positions[self.atom_indices]
         return context
 
-class SideChainMove(object):
+class SideChainMove(Move):
     """Move that provides methods for:
         1. calculating the properties needed to rotate a sidechain residue
         of a structure in the NCMC simulation

--- a/blues/moves.py
+++ b/blues/moves.py
@@ -63,12 +63,60 @@ class Move(object):
         return new_sys, new_int
 
     def beforeMove(self, context):
+        """This method is called at the start of the NCMC portion if the
+        context needs to be checked or modified before performing the move
+        at the halfway point.
+
+        Parameters
+        ----------
+        context: simtk.openmm.Context object
+            Context containing the positions to be moved.
+
+        Returns
+        -------
+        context: simtk.openmm.Context object
+            The same input context, but whose context were changed by this function.
+
+        """
         return context
         
     def afterMove(self, context):
+        """This method is called at the end of the NCMC portion if the
+        context needs to be checked or modified before performing the move
+        at the halfway point.
+
+        Parameters
+        ----------
+        context: simtk.openmm.Context object
+            Context containing the positions to be moved.
+
+        Returns
+        -------
+        context: simtk.openmm.Context object
+            The same input context, but whose context were changed by this function.
+
+        """
+
         return context
         
     def _error(self, context):
+        """This method is called if running during NCMC portion results
+        in an error. This allows portions of the context, such as the
+        context parameters that would not be fixed by just reverting the
+        positions/velocities of the context.
+
+        Parameters
+        ----------
+        context: simtk.openmm.Context object
+            Context containing the positions to be moved.
+
+        Returns
+        -------
+        context: simtk.openmm.Context object
+            The same input context, but whose context were changed by this function.
+
+        """
+
         return context
 
     def move(self, context):

--- a/blues/moves.py
+++ b/blues/moves.py
@@ -39,8 +39,8 @@ class Move(object):
         Currently empy.
         """
 
-    def initializeSystem(self, system):
-        """If the system needs to be modified to perform the move
+    def initializeSystem(self, system, integrator):
+        """If the system or integrator needs to be modified to perform the move
         ex. adding a force this method is called during the start
         of the simulation to change the system.
 
@@ -48,21 +48,27 @@ class Move(object):
         ----------
         system : simtk.openmm.System object
             System to be modified.
-
+        integrator : simtk.openmm.Integrator object
+            Integrator to be modified.
         Returns
         -------
         system : simtk.openmm.System object
             The modified System object.
+        integrator : simtk.openmm.Integrator object
+            The modified Integrator object.
+
         """
         new_sys = system
-        return new_sys
+        new_int = integrator
+        return new_sys, new_int
 
     def beforeMove(self, context):
         return context
         
     def afterMove(self, context):
         return context
-
+    def _error(self, context):
+        return context
 
     def move(self, context):
         return context

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -548,6 +548,21 @@ class Simulation(object):
             values = [nc_step, speed, self.accept, self.current_iter]
             self.log.info('\t\t'.join(str(v) for v in values))
 
+    def _initialize_moves(self):
+        state = self.nc_sim.context.getState(getPositions=True, getVelocities=True)
+        print('box vectors', state.getPeriodicBoxVectors())
+        pos = state.getPositions()
+        vel = state.getVelocities()
+        print(self.nc_sim.context.getSystem().getForces())
+        for move in self.move_engine.moves:
+            system = self.nc_sim.system
+            new_sys = move.initializeSystem(system)
+            self.nc_sim.system = new_sys
+        self.nc_sim.context.reinitialize()
+        self.nc_sim.context.setPositions(pos)
+        self.nc_sim.context.setVelocities(vel)
+
+
     def run(self, nIter=100):
         """Function that runs the BLUES engine to iterate over the actions:
         Perform NCMC simulation, perform proposed move, accepts/rejects move,
@@ -556,6 +571,7 @@ class Simulation(object):
         self.log.info('Running %i BLUES iterations...' % (nIter))
         self._getSimulationInfo()
         #set inital conditions
+        self._initialize_moves()
         self.setStateConditions()
         for n in range(int(nIter)):
             self.current_iter = int(n)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -478,6 +478,9 @@ class Simulation(object):
             start = time.time()
             self._initialSimulationTime = self.nc_context.getState().getTime()
             try:
+                #Attempt anything related to the move before protocol is performed
+                if nc_step == 0:
+                    self.nc_context = self.move_engine.moves[self.move_engine.selected_move].beforeMove(self.nc_context)
                 # Attempt selected MoveEngine Move at the halfway point
                 #to ensure protocol is symmetric
                 if self.movestep == nc_step:
@@ -495,6 +498,10 @@ class Simulation(object):
                     self.log.debug('%s' % work)
                 if ncmc_traj:
                     self.ncmc_reporter.report(self.nc_sim, self.nc_context.getState(getPositions=True, getVelocities=True))
+
+                #Attempt anything related to the move after protocol is performed
+                if nc_step == nstepsNC-1:
+                    self.nc_context = self.move_engine.moves[self.move_engine.selected_move].afterMove(self.nc_context)
 
             except Exception as e:
                 self.log.error(e)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -61,7 +61,7 @@ class SimulationFactory(object):
         #Atom indicies from move_engine
         #TODO: change atom_indices selection for multiple regions
         self.atom_indices = move_engine.moves[0].atom_indices
-
+        self.move_engine = move_engine
         self.system = None
         self.alch_system = None
         self.md = None
@@ -138,7 +138,7 @@ class SimulationFactory(object):
                             hydrogenMass=hydrogenMass)
         return system
 
-    def generateSimFromStruct(self, structure, system, nIter, nstepsNC, nstepsMD,
+    def generateSimFromStruct(self, structure, move_engine, system, nIter, nstepsNC, nstepsMD,
                              temperature=300, dt=0.002, friction=1,
                              reporter_interval=1000, nprop=1, prop_lambda=0.3,
                              ncmc=False, platform=None, verbose=True,
@@ -175,10 +175,15 @@ class SimulationFactory(object):
                                    nprop=nprop,
                                    prop_lambda=prop_lambda
                                    )
+
+            for move in move_engine.moves:
+                system, integrator = move.initializeSystem(system, integrator)
+
         else:
             integrator = openmm.LangevinIntegrator(temperature*unit.kelvin,
                                                    friction/unit.picosecond,
                                                    dt*unit.picoseconds)
+
         #TODO SIMPLIFY TO 1 LINE.
         #Specifying platform properties here used for local development.
         if platform is None:
@@ -210,9 +215,9 @@ class SimulationFactory(object):
         """Function used to generate the 3 OpenMM Simulation objects."""
         self.system = self.generateSystem(self.structure, **self.opt)
         self.alch_system = self.generateAlchSystem(self.system, self.atom_indices, **self.opt)
-        self.md = self.generateSimFromStruct(self.structure, self.system, **self.opt)
-        self.alch = self.generateSimFromStruct(self.structure, self.system,  **self.opt)
-        self.nc = self.generateSimFromStruct(self.structure, self.alch_system,
+        self.md = self.generateSimFromStruct(self.structure, self.move_engine, self.system, **self.opt)
+        self.alch = self.generateSimFromStruct(self.structure, self.move_engine, self.system,  **self.opt)
+        self.nc = self.generateSimFromStruct(self.structure, self.move_engine, self.alch_system,
                                             ncmc=True, **self.opt)
 
 
@@ -549,22 +554,6 @@ class Simulation(object):
             values = [nc_step, speed, self.accept, self.current_iter]
             self.log.info('\t\t'.join(str(v) for v in values))
 
-    def _initialize_moves(self):
-        state = self.nc_sim.context.getState(getPositions=True, getVelocities=True)
-        print('box vectors', state.getPeriodicBoxVectors())
-        pos = state.getPositions()
-        vel = state.getVelocities()
-        print(self.nc_sim.context.getSystem().getForces())
-        for move in self.move_engine.moves:
-            system = self.nc_sim.system
-            integrator = self.nc_sim.integrator
-            new_sys, new_integrator = move.initializeSystem(system, integrator)
-            self.nc_sim.system = new_sys
-        self.nc_sim.context.reinitialize()
-        self.nc_sim.context.setPositions(pos)
-        self.nc_sim.context.setVelocities(vel)
-
-
     def run(self, nIter=100):
         """Function that runs the BLUES engine to iterate over the actions:
         Perform NCMC simulation, perform proposed move, accepts/rejects move,
@@ -573,7 +562,6 @@ class Simulation(object):
         self.log.info('Running %i BLUES iterations...' % (nIter))
         self._getSimulationInfo()
         #set inital conditions
-        self._initialize_moves()
         self.setStateConditions()
         for n in range(int(nIter)):
             self.current_iter = int(n)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -505,6 +505,7 @@ class Simulation(object):
 
             except Exception as e:
                 self.log.error(e)
+                self.move_engine.moves[self.move_engine.selected_move]._error(self.nc_context)
                 break
 
             self._report(start, nc_step)
@@ -556,7 +557,8 @@ class Simulation(object):
         print(self.nc_sim.context.getSystem().getForces())
         for move in self.move_engine.moves:
             system = self.nc_sim.system
-            new_sys = move.initializeSystem(system)
+            integrator = self.nc_sim.integrator
+            new_sys, new_integrator = move.initializeSystem(system, integrator)
             self.nc_sim.system = new_sys
         self.nc_sim.context.reinitialize()
         self.nc_sim.context.setPositions(pos)

--- a/blues/tests/test_blues.py
+++ b/blues/tests/test_blues.py
@@ -57,10 +57,10 @@ class BLUESTester(unittest.TestCase):
         alch_system = sims.generateAlchSystem(system, move.atom_indices)
         self.assertIsInstance(alch_system, openmm.System)
 
-        md_sim = sims.generateSimFromStruct(self.full_struct, system, **self.opt)
+        md_sim = sims.generateSimFromStruct(self.full_struct, engine, system, **self.opt)
         self.assertIsInstance(md_sim, openmm.app.simulation.Simulation)
 
-        nc_sim = sims.generateSimFromStruct(self.full_struct, alch_system, ncmc=True, **self.opt)
+        nc_sim = sims.generateSimFromStruct(self.full_struct, engine, alch_system, ncmc=True, **self.opt)
         self.assertIsInstance(nc_sim, openmm.app.simulation.Simulation)
 
     def test_simulationRun(self):
@@ -90,7 +90,7 @@ class BLUESTester(unittest.TestCase):
         system = sims.generateSystem(structure, **self.opt)
         simdict = sims.createSimulationSet()
         alch_system = sims.generateAlchSystem(system, self.model.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.mover, alch_system, ncmc=True, **self.opt)
         self.model.calculateProperties()
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
         asim = Simulation(sims, self.mover, **self.opt)

--- a/blues/tests/test_mc.py
+++ b/blues/tests/test_mc.py
@@ -93,7 +93,7 @@ class BLUESTester(unittest.TestCase):
         system = sims.generateSystem(structure, **self.opt)
         simdict = sims.createSimulationSet()
         alch_system = sims.generateAlchSystem(system, self.model.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.mover, alch_system, ncmc=True, **self.opt)
         self.model.calculateProperties()
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
         mc_sim = Simulation(sims, self.mover, **self.opt)

--- a/blues/tests/test_moveproposal.py
+++ b/blues/tests/test_moveproposal.py
@@ -34,7 +34,7 @@ class MoveEngineTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, ncmc=True, **self.opt)
 
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 

--- a/blues/tests/test_smartdart.py
+++ b/blues/tests/test_smartdart.py
@@ -47,7 +47,7 @@ class SmartDartTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.move_engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.move.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.move_engine, alch_system, ncmc=True, **self.opt)
         self.move.calculateProperties()
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 

--- a/blues/tests/test_smartdart.py
+++ b/blues/tests/test_smartdart.py
@@ -149,7 +149,7 @@ class DartLoaderTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, self.engine, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, ncmc=True, **self.opt)
 
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 

--- a/blues/tests/test_smartdart.py
+++ b/blues/tests/test_smartdart.py
@@ -149,7 +149,7 @@ class DartLoaderTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, self.engine, ncmc=True, **self.opt)
 
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 

--- a/blues/tests/test_smartdart.py
+++ b/blues/tests/test_smartdart.py
@@ -47,7 +47,7 @@ class SmartDartTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.move_engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.move.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, ncmc=True, **self.opt)
         self.move.calculateProperties()
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 
@@ -149,7 +149,7 @@ class DartLoaderTester(unittest.TestCase):
         sims = SimulationFactory(structure, self.engine, **self.opt)
         system = sims.generateSystem(structure, **self.opt)
         alch_system = sims.generateAlchSystem(system, self.atom_indices)
-        self.nc_sim = sims.generateSimFromStruct(structure, alch_system, self.engine, ncmc=True, **self.opt)
+        self.nc_sim = sims.generateSimFromStruct(structure, self.engine, alch_system, self.engine, ncmc=True, **self.opt)
 
         self.initial_positions = self.nc_sim.context.getState(getPositions=True).getPositions(asNumpy=True)
 


### PR DESCRIPTION
Changes some of the framework in `simulation.py` to allow for the following cases:

Allows moves to have a `beforeMove` and `afterMove` methods, which is executed at the start and end of an NCMC portion of an iteration.

Also this PR introduces the possibility of moves changing the system or integrator, which primarily would come into effect when restraint forces need to be added for moves.