### PR TITLE
HDF5 reporter and StateDataReporter for NCMC simulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,11 @@ script:
     - conda config --add channels ${ORGNAME}
     - conda create -q -n testenv python=$python
     - source activate testenv
-    - conda install --yes -c omnia openmmtools=0.13.0
-    - conda install --yes -c omnia parmed=2.7.3
-    - conda install --yes -c omnia mdtraj=1.9.1
     - conda install --yes -c openeye/label/Orion oeommtools
     # Use beta version for partial bond orders
     - pip install --pre -i https://pypi.anaconda.org/openeye/label/beta/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
     - conda build --python $python devtools/conda-recipe
-    - conda install --yes -c local blues
+    - conda install --yes blues --use-local
     - conda list
     - py.test -v blues
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
     - conda create -q -n testenv python=$python
     - source activate testenv
     - conda install --yes -c openeye/label/Orion oeommtools
+    - conda install -c omnia mdtraj=1.9.1 parmed=2.7.1 openmmtools=0.13.0
     # Use beta version for partial bond orders
     - pip install --pre -i https://pypi.anaconda.org/openeye/label/beta/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
     - conda build --python $python devtools/conda-recipe

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ script:
     - conda config --add channels ${ORGNAME}
     - conda create -q -n testenv python=$python
     - source activate testenv
-    - conda install --yes -c omnia openmmtools
-    - conda install --yes -c omnia parmed
-    - conda install --yes -c omnia mdtraj
+    - conda install --yes -c omnia openmmtools=0.13.0
+    - conda install --yes -c omnia parmed=2.7.3
+    - conda install --yes -c omnia mdtraj=1.9.1
     - conda install --yes -c openeye/label/Orion oeommtools
     # Use beta version for partial bond orders
     - pip install --pre -i https://pypi.anaconda.org/openeye/label/beta/simple openeye-toolkits && python -c "import openeye; print(openeye.__version__)"

--- a/blues/__init__.py
+++ b/blues/__init__.py
@@ -6,4 +6,4 @@ BLUES
 # Define global version.
 from . import version
 __version__ = version.version
-from blues import moves, engine, ncmc_switching, simulation, utils
+from blues import moves, engine, ncmc_switching, simulation, utils, reporters

--- a/blues/__init__.py
+++ b/blues/__init__.py
@@ -6,4 +6,4 @@ BLUES
 # Define global version.
 from . import version
 __version__ = version.version
-from blues import moves, engine, ncmc_switching, simulation, utils, reporters
+from blues import moves, engine, ncmc_switching, simulation, utils

--- a/blues/example.py
+++ b/blues/example.py
@@ -34,12 +34,13 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
             'nIter' : 100, 'nstepsNC' : 10000, 'nstepsMD' : 10000, 'nprop' : 1,
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10,
             'constraints': 'HBonds', 'freeze_distance' : 5.0,
-            'trajectory_interval' : 2000, 'reporter_interval' : 2000,
-            'ncmc_traj' : None, 'write_move' : False,
+            'trajectory_interval' : 2000, 'reporter_interval' : 1000,
+            'write_move' : False,
             'platform' : platform_name,
             'outfname' : 't4-toluene'}
 
-    logger = init_logger(level=logging.INFO, outfname=opt['outfname'])
+
+    logger = init_logger(logging.getLogger(), level=logging.INFO, outfname=opt['outfname'])
     opt['Logger'] = logger
 
     #Define the 'model' object we are perturbing here.
@@ -55,7 +56,7 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
     simulations.createSimulationSet()
 
     # Add reporters to MD simulation.
-    traj_reporter = openmm.app.DCDReporter(outfname+'-nc{}.dcd'.format(nstepsNC), opt['trajectory_interval'])
+    traj_reporter = openmm.app.DCDReporter(opt['outfname']+'-nc{}.dcd'.format(nstepsNC), opt['trajectory_interval'])
     md_progress_reporter = BLUESStateDataReporter(logger, separator="\t", title='md',
                                 reportInterval=opt['reporter_interval'],
                                 step=True, totalSteps=opt['nIter']*opt['nstepsMD'],
@@ -64,7 +65,7 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
     simulations.md.reporters.append(md_progress_reporter)
 
     # Add reporters to NCMC simulation.
-    ncmc_reporter = BLUESHDF5Reporter(file='t4tol-pmoves.h5',
+    ncmc_reporter = BLUESHDF5Reporter(file=opt['outfname']+'-pmoves.h5',
                                     reportInterval=1,
                                     coordinates=True, frame_indices=[1,opt['nstepsNC']],
                                     time=False, cell=True, temperature=False,

--- a/blues/example.py
+++ b/blues/example.py
@@ -20,7 +20,7 @@ from simtk import openmm
 from optparse import OptionParser
 import sys
 import logging
-
+from blues.reporters import init_logger, BLUESHDF5Reporter, BLUESStateDataReporter
 
 def runNCMC(platform_name, nstepsNC, nprop, outfname):
 
@@ -28,20 +28,19 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
     prmtop = utils.get_data_filename('blues', 'tests/data/eqToluene.prmtop')#
     inpcrd = utils.get_data_filename('blues', 'tests/data/eqToluene.inpcrd')
     struct = parmed.load_file(prmtop, xyz=inpcrd)
-    print('Structure: %s' % struct.topology)
 
     #Define some options
     opt = { 'temperature' : 300.0, 'friction' : 1, 'dt' : 0.002,
-            'nIter' : 100, 'nstepsNC' : nstepsNC, 'nstepsMD' : 5000, 'nprop' : nprop,
+            'nIter' : 100, 'nstepsNC' : 10000, 'nstepsMD' : 10000, 'nprop' : 1,
             'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10,
             'constraints': 'HBonds', 'freeze_distance' : 5.0,
-            'trajectory_interval' : 1000, 'reporter_interval' : 1000,
-            'ncmc_traj' : None, 'write_move' : True,
+            'trajectory_interval' : 2000, 'reporter_interval' : 2000,
+            'ncmc_traj' : None, 'write_move' : False,
             'platform' : platform_name,
-            'outfname' : 't4-tol',
-            'verbose' : False}
+            'outfname' : 't4-toluene'}
 
-
+    logger = init_logger(level=logging.INFO, outfname=opt['outfname'])
+    opt['Logger'] = logger
 
     #Define the 'model' object we are perturbing here.
     # Calculate particle masses of object to be moved
@@ -57,12 +56,28 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
 
     # Add reporters to MD simulation.
     traj_reporter = openmm.app.DCDReporter(outfname+'-nc{}.dcd'.format(nstepsNC), opt['trajectory_interval'])
-    progress_reporter = openmm.app.StateDataReporter(sys.stdout, separator="\t",
+    md_progress_reporter = BLUESStateDataReporter(logger, separator="\t", title='md',
                                 reportInterval=opt['reporter_interval'],
                                 step=True, totalSteps=opt['nIter']*opt['nstepsMD'],
-                                time=True, speed=True, progress=True, remainingTime=True)
+                                time=False, speed=True, progress=True, remainingTime=True)
     simulations.md.reporters.append(traj_reporter)
-    simulations.md.reporters.append(progress_reporter)
+    simulations.md.reporters.append(md_progress_reporter)
+
+    # Add reporters to NCMC simulation.
+    ncmc_reporter = BLUESHDF5Reporter(file='t4tol-pmoves.h5',
+                                    reportInterval=1,
+                                    coordinates=True, frame_indices=[1,opt['nstepsNC']],
+                                    time=False, cell=True, temperature=False,
+                                    potentialEnergy=False, kineticEnergy=False,
+                                    velocities=False, atomSubset=None,
+                                    protocolWork=True, alchemicalLambda=True,
+                                    parameters=opt, environment=True)
+    ncmc_progress_reporter = BLUESStateDataReporter(logger, separator="\t", title='ncmc',
+                                reportInterval=opt['reporter_interval'],
+                                step=True, totalSteps=opt['nstepsNC'],
+                                time=False, speed=True, progress=True, remainingTime=True)
+    simulations.nc.reporters.append(ncmc_reporter)
+    simulations.nc.reporters.append(ncmc_progress_reporter)
 
     # Run BLUES Simulation
     blues = Simulation(simulations, ligand_mover, **opt)
@@ -71,9 +86,9 @@ def runNCMC(platform_name, nstepsNC, nprop, outfname):
 parser = OptionParser()
 parser.add_option('-f', '--force', action='store_true', default=False,
                   help='run BLUES example without GPU platform')
-parser.add_option('-n','--ncmc', dest='nstepsNC', type='int', default=5000,
+parser.add_option('-n','--ncmc', dest='nstepsNC', type='int', default=100,
                   help='number of NCMC steps')
-parser.add_option('-p','--nprop', dest='nprop', type='int', default=5,
+parser.add_option('-p','--nprop', dest='nprop', type='int', default=1,
                   help='number of propgation steps')
 parser.add_option('-o','--output', dest='outfname', type='str', default="blues",
                   help='Filename for output DCD')

--- a/blues/reporters.py
+++ b/blues/reporters.py
@@ -1,0 +1,381 @@
+from mdtraj.formats.hdf5 import HDF5TrajectoryFile
+from mdtraj.reporters import HDF5Reporter
+import simtk.unit as units
+import json, yaml
+import subprocess
+import numpy as np
+from mdtraj.utils import unitcell
+from mdtraj.utils import in_units_of, ensure_type
+
+import mdtraj.version
+import simtk.openmm.version
+import blues.version
+
+class BLUESHDF5TrajectoryFile(HDF5TrajectoryFile):
+    #This is a subclass of the HDF5TrajectoryFile class from mdtraj that handles the writing of
+    #the trajectory information to the HDF5 file format.
+    def __init__(self, filename, mode='r', force_overwrite=True, compression='zlib'):
+        super(BLUESHDF5TrajectoryFile, self).__init__(filename, mode, force_overwrite, compression)
+
+
+    def write(self, coordinates, parameters=None, environment=None,
+                    time=None, cell_lengths=None, cell_angles=None,
+                    velocities=None, kineticEnergy=None, potentialEnergy=None,
+                    temperature=None, alchemicalLambda=None,
+                    protocolWork=None, title=None):
+        """Write one or more frames of data to the file
+        This method saves data that is associated with one or more simulation
+        frames. Note that all of the arguments can either be raw numpy arrays
+        or unitted arrays (with simtk.unit.Quantity). If the arrays are unittted,
+        a unit conversion will be automatically done from the supplied units
+        into the proper units for saving on disk. You won't have to worry about
+        it.
+        Furthermore, if you wish to save a single frame of simulation data, you
+        can do so naturally, for instance by supplying a 2d array for the
+        coordinates and a single float for the time. This "shape deficiency"
+        will be recognized, and handled appropriately.
+        Parameters
+        ----------
+        coordinates : np.ndarray, shape=(n_frames, n_atoms, 3)
+            The cartesian coordinates of the atoms to write. By convention, the
+            lengths should be in units of nanometers.
+        time : np.ndarray, shape=(n_frames,), optional
+            You may optionally specify the simulation time, in picoseconds
+            corresponding to each frame.
+        cell_lengths : np.ndarray, shape=(n_frames, 3), dtype=float32, optional
+            You may optionally specify the unitcell lengths.
+            The length of the periodic box in each frame, in each direction,
+            `a`, `b`, `c`. By convention the lengths should be in units
+            of angstroms.
+        cell_angles : np.ndarray, shape=(n_frames, 3), dtype=float32, optional
+            You may optionally specify the unitcell angles in each frame.
+            Organized analogously to cell_lengths. Gives the alpha, beta and
+            gamma angles respectively. By convention, the angles should be
+            in units of degrees.
+        velocities :  np.ndarray, shape=(n_frames, n_atoms, 3), optional
+            You may optionally specify the cartesian components of the velocity
+            for each atom in each frame. By convention, the velocities
+            should be in units of nanometers / picosecond.
+        kineticEnergy : np.ndarray, shape=(n_frames,), optional
+            You may optionally specify the kinetic energy in each frame. By
+            convention the kinetic energies should b in units of kilojoules per
+            mole.
+        potentialEnergy : np.ndarray, shape=(n_frames,), optional
+            You may optionally specify the potential energy in each frame. By
+            convention the kinetic energies should b in units of kilojoules per
+            mole.
+        temperature : np.ndarray, shape=(n_frames,), optional
+            You may optionally specify the temperature in each frame. By
+            convention the temperatures should b in units of Kelvin.
+        alchemicalLambda : np.ndarray, shape=(n_frames,), optional
+            You may optionally specify the alchemical lambda in each frame. These
+            have no units, but are generally between zero and one.
+        """
+        _check_mode(self.mode, ('w', 'a'))
+
+        # these must be either both present or both absent. since
+        # we're going to throw an error if one is present w/o the other,
+        # lets do it now.
+        if cell_lengths is None and cell_angles is not None:
+            raise ValueError('cell_lengths were given, but no cell_angles')
+        if cell_lengths is not None and cell_angles is None:
+            raise ValueError('cell_angles were given, but no cell_lengths')
+
+        # if the input arrays are simtk.unit.Quantities, convert them
+        # into md units. Note that this acts as a no-op if the user doesn't
+        # have simtk.unit installed (e.g. they didn't install OpenMM)
+        coordinates = in_units_of(coordinates, None, 'nanometers')
+        time = in_units_of(time, None, 'picoseconds')
+        cell_lengths = in_units_of(cell_lengths, None, 'nanometers')
+        cell_angles = in_units_of(cell_angles, None, 'degrees')
+        velocities = in_units_of(velocities, None, 'nanometers/picosecond')
+        kineticEnergy = in_units_of(kineticEnergy, None, 'kilojoules_per_mole')
+        potentialEnergy = in_units_of(potentialEnergy, None, 'kilojoules_per_mole')
+        temperature = in_units_of(temperature, None, 'kelvin')
+        alchemicalLambda = in_units_of(alchemicalLambda, None, 'dimensionless')
+        protocolWork = in_units_of(protocolWork, None, 'kT')
+
+        # do typechecking and shapechecking on the arrays
+        # this ensure_type method has a lot of options, but basically it lets
+        # us validate most aspects of the array. Also, we can upconvert
+        # on defficent ndim, which means that if the user sends in a single
+        # frame of data (i.e. coordinates is shape=(n_atoms, 3)), we can
+        # realize that. obviously the default mode is that they want to
+        # write multiple frames at a time, so the coordinate shape is
+        # (n_frames, n_atoms, 3)
+        coordinates = ensure_type(coordinates, dtype=np.float32, ndim=3,
+            name='coordinates', shape=(None, None, 3), can_be_none=False,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        n_frames, n_atoms, = coordinates.shape[0:2]
+        time = ensure_type(time, dtype=np.float32, ndim=1,
+            name='time', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        cell_lengths = ensure_type(cell_lengths, dtype=np.float32, ndim=2,
+            name='cell_lengths', shape=(n_frames, 3), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        cell_angles = ensure_type(cell_angles, dtype=np.float32, ndim=2,
+            name='cell_angles', shape=(n_frames, 3), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        velocities = ensure_type(velocities, dtype=np.float32, ndim=3,
+            name='velocoties', shape=(n_frames, n_atoms, 3), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        kineticEnergy = ensure_type(kineticEnergy, dtype=np.float32, ndim=1,
+            name='kineticEnergy', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        potentialEnergy = ensure_type(potentialEnergy, dtype=np.float32, ndim=1,
+            name='potentialEnergy', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        temperature = ensure_type(temperature, dtype=np.float32, ndim=1,
+            name='temperature', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        alchemicalLambda = ensure_type(alchemicalLambda, dtype=np.float32, ndim=1,
+            name='alchemicalLambda', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+        protocolWork = ensure_type(protocolWork, dtype=np.float32, ndim=1,
+            name='protocolWork', shape=(n_frames,), can_be_none=True,
+            warn_on_cast=False, add_newaxis_on_deficient_ndim=True)
+
+        # if this is our first call to write(), we need to create the headers
+        # and the arrays in the underlying HDF5 file
+        if self._needs_initialization:
+            self._initialize_headers(
+                n_atoms=n_atoms,
+                title=title,
+                parameters=parameters,
+                set_environment=(environment is not None),
+                set_coordinates=True,
+                set_time=(time is not None),
+                set_cell=(cell_lengths is not None or cell_angles is not None),
+                set_velocities=(velocities is not None),
+                set_kineticEnergy=(kineticEnergy is not None),
+                set_potentialEnergy=(potentialEnergy is not None),
+                set_temperature=(temperature is not None),
+                set_alchemicalLambda=(alchemicalLambda is not None),
+                set_protocolWork=(protocolWork is not None))
+
+            self._needs_initialization = False
+
+            # we need to check that that the entries that the user is trying
+            # to save are actually fields in OUR file
+
+        try:
+            # try to get the nodes for all of the fields that we have
+            # which are not None
+            for name in ['coordinates', 'time', 'cell_angles', 'cell_lengths',
+                         'velocities', 'kineticEnergy', 'potentialEnergy', 'temperature', 'protocolWork', 'alchemicalLambda']:
+                contents = locals()[name]
+                if contents is not None:
+                    self._get_node(where='/', name=name).append(contents)
+                if contents is None:
+                    # for each attribute that they're not saving, we want
+                    # to make sure the file doesn't explect it
+                    try:
+                        self._get_node(where='/', name=name)
+                        raise AssertionError()
+                    except self.tables.NoSuchNodeError:
+                        pass
+
+        except self.tables.NoSuchNodeError:
+            raise ValueError("The file that you're trying to save to doesn't "
+                "contain the field %s. You can always save a new trajectory "
+                "and have it contain this information, but I don't allow 'ragged' "
+                "arrays. If one frame is going to have %s information, then I expect "
+                "all of them to. So I can't save it for just these frames. Sorry "
+                "about that :)" % (name, name))
+        except AssertionError:
+            raise ValueError("The file that you're saving to expects each frame "
+                            "to contain %s information, but you did not supply it."
+                            "I don't allow 'ragged' arrays. If one frame is going "
+                            "to have %s information, then I expect all of them to. "
+                            % (name, name))
+
+        self._frame_index += n_frames
+        self.flush()
+
+    def _initialize_headers(self, n_atoms, title, parameters, set_environment,
+                            set_coordinates, set_time, set_cell,
+                            set_velocities, set_kineticEnergy, set_potentialEnergy,
+                            set_temperature, set_alchemicalLambda, set_protocolWork):
+        self._n_atoms = n_atoms
+        self._parameters = parameters
+        self._handle.root._v_attrs.title = np.string_(title)
+        self._handle.root._v_attrs.conventions = np.string_('Pande')
+        self._handle.root._v_attrs.conventionVersion = np.string_('1.1')
+        self._handle.root._v_attrs.program = np.string_('MDTraj')
+        self._handle.root._v_attrs.programVersion = np.string_(mdtraj.version.full_version)
+        self._handle.root._v_attrs.method = np.string_('BLUES')
+        self._handle.root._v_attrs.methodVersion = np.string_(blues.version.full_version)
+        self._handle.root._v_attrs.reference = np.string_('DOI: 10.1021/acs.jpcb.7b11820')
+
+        if not hasattr(self._handle.root._v_attrs, 'application'):
+            self._handle.root._v_attrs.application = np.string_('OpenMM')
+            self._handle.root._v_attrs.applicationVersion = np.string_(simtk.openmm.version.full_version)
+
+        # create arrays that store frame level informat
+        if set_coordinates:
+            self._create_earray(where='/', name='coordinates',
+                atom=self.tables.Float32Atom(), shape=(0, self._n_atoms, 3))
+            self._handle.root.coordinates.attrs['units'] = np.string_('nanometers')
+
+        if set_time:
+            self._create_earray(where='/', name='time',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.time.attrs['units'] = np.string_('picoseconds')
+
+        if set_cell:
+            self._create_earray(where='/', name='cell_lengths',
+                atom=self.tables.Float32Atom(), shape=(0, 3))
+            self._create_earray(where='/', name='cell_angles',
+                atom=self.tables.Float32Atom(), shape=(0, 3))
+            self._handle.root.cell_lengths.attrs['units'] = np.string_('nanometers')
+            self._handle.root.cell_angles.attrs['units'] = np.string_('degrees')
+
+        if set_velocities:
+            self._create_earray(where='/', name='velocities',
+                atom=self.tables.Float32Atom(), shape=(0, self._n_atoms, 3))
+            self._handle.root.velocities.attrs['units'] = np.string_('nanometers/picosecond')
+
+        if set_kineticEnergy:
+            self._create_earray(where='/', name='kineticEnergy',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.kineticEnergy.attrs['units'] = np.string_('kilojoules_per_mole')
+
+        if set_potentialEnergy:
+            self._create_earray(where='/', name='potentialEnergy',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.potentialEnergy.attrs['units'] = np.string_('kilojoules_per_mole')
+
+        if set_temperature:
+            self._create_earray(where='/', name='temperature',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.temperature.attrs['units'] = np.string_('kelvin')
+
+        #Add another portion akin to this if you want to store more data in the h5 file
+        if set_alchemicalLambda:
+            self._create_earray(where='/', name='alchemicalLambda',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.alchemicalLambda.attrs['units'] = np.string_('dimensionless')
+
+        if set_protocolWork:
+            self._create_earray(where='/', name='protocolWork',
+                atom=self.tables.Float32Atom(), shape=(0,))
+            self._handle.root.protocolWork.attrs['units'] = np.string_('kT')
+
+        if parameters:
+            data = json.dumps(self._parameters)
+            if not isinstance(data, bytes):
+                data = data.encode('ascii')
+            if self.tables.__version__ >= '3.0.0':
+                self._handle.create_array(where='/', name='parameters', obj=[data])
+            else:
+                self._handle.createArray(where='/', name='parameters', object=[data])
+
+        if set_environment:
+            try:
+                envout = subprocess.check_output('conda env export --no-builds', shell=True, stderr=subprocess.STDOUT)
+                envjson = json.dumps(yaml.load(envout), sort_keys=True, indent=2)
+                if not isinstance(envjson, bytes):
+                    envjson = envjson.encode('ascii')
+                if self.tables.__version__ >= '3.0.0':
+                    self._handle.create_array(where='/', name='environment', obj=[envjson])
+                else:
+                    self._handle.createArray(where='/', name='environment', object=[envjson])
+            except Exception as e:
+                print(e)
+                pass
+
+class BLUESReporter(HDF5Reporter):
+    #This is a subclass of the HDF5 class from mdtraj that handles the reporting of
+    #the trajectory.
+    @property
+    def backend(self):
+        return BLUESHDF5TrajectoryFile
+
+    def __init__(self, file, reportInterval,
+                 title='NCMC Trajectory',
+                 coordinates=True, all_coordinates=False,
+                 time=False, cell=True, temperature=False,
+                 potentialEnergy=False, kineticEnergy=False,
+                 velocities=False, atomSubset=None,
+                 protocolWork=True, alchemicalLambda=True,
+                 parameters=None, environment=True):
+
+        super(BLUESReporter, self).__init__(file, reportInterval,
+            coordinates, time, cell, potentialEnergy, kineticEnergy,
+            temperature, velocities, atomSubset)
+
+        self._protocolWork = bool(protocolWork)
+        self._alchemicalLambda = bool(alchemicalLambda)
+        self._all_coordinates = bool(all_coordinates)
+        self._environment = bool(environment)
+        self._title = title
+        self._parameters = parameters
+
+    def report(self, simulation, state):
+        """Generate a report.
+        Parameters
+        ----------
+        simulation : simtk.openmm.app.Simulation
+            The Simulation to generate a report for
+        state : simtk.openmm.State
+            The current state of the simulation
+        """
+        if not self._is_intialized:
+            self._initialize(simulation)
+            self._is_intialized = True
+
+        self._checkForErrors(simulation, state)
+
+        args = ()
+        kwargs = {}
+        nsteps = simulation.integrator.getGlobalVariableByName('nsteps')
+        if self._coordinates:
+            coordinates = state.getPositions(asNumpy=True)[self._atomSlice]
+            coordinates = coordinates.value_in_unit(getattr(units, self._traj_file.distance_unit))
+            if not self._all_coordinates:
+                if simulation.currentStep not in [1, nsteps]:
+                    coordinates = np.zeros(coordinates.shape)
+            args = (coordinates,)
+        if self._time:
+            kwargs['time'] = state.getTime()
+        if self._cell:
+            vectors = state.getPeriodicBoxVectors(asNumpy=True)
+            vectors = vectors.value_in_unit(getattr(units, self._traj_file.distance_unit))
+            a, b, c, alpha, beta, gamma = unitcell.box_vectors_to_lengths_and_angles(*vectors)
+            kwargs['cell_lengths'] = np.array([a, b, c])
+            kwargs['cell_angles'] = np.array([alpha, beta, gamma])
+        if self._potentialEnergy:
+            kwargs['potentialEnergy'] = state.getPotentialEnergy()
+        if self._kineticEnergy:
+            kwargs['kineticEnergy'] = state.getKineticEnergy()
+        if self._temperature:
+            kwargs['temperature'] = 2*state.getKineticEnergy()/(self._dof*units.MOLAR_GAS_CONSTANT_R)
+        if self._velocities:
+            kwargs['velocities'] = state.getVelocities(asNumpy=True)[self._atomSlice, :]
+
+        #add a portion like this to store things other than the protocol work
+        if self._protocolWork:
+            protocol_work = simulation.integrator.get_protocol_work(dimensionless=True)
+            kwargs['protocolWork'] = np.array([protocol_work])
+        if self._alchemicalLambda:
+            kwargs['alchemicalLambda'] = np.array([simulation.integrator.getGlobalVariableByName('lambda')])
+        if self._title:
+            kwargs['title'] = self._title
+        if self._parameters:
+            kwargs['parameters'] = self._parameters
+        if self._environment:
+            kwargs['environment'] = self._environment
+
+        self._traj_file.write(*args, **kwargs)
+        # flush the file to disk. it might not be necessary to do this every
+        # report, but this is the most proactive solution. We don't want to
+        # accumulate a lot of data in memory only to find out, at the very
+        # end of the run, that there wasn't enough space on disk to hold the
+        # data.
+        if hasattr(self._traj_file, 'flush'):
+            self._traj_file.flush()
+
+def _check_mode(m, modes):
+    if m not in modes:
+        raise ValueError('This operation is only available when a file '
+                         'is open in mode="%s".' % m)

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -480,7 +480,7 @@ class Simulation(object):
                     self.nc_sim.context = self.move_engine.moves[self.move_engine.selected_move].afterMove(self.nc_sim.context)
 
             except Exception as e:
-                self.log.info(e)
+                self.log.error(e)
                 self.move_engine.moves[self.move_engine.selected_move]._error(self.nc_sim.context)
                 break
 

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -244,6 +244,7 @@ class Simulation(object):
         if 'Logger' in opt:
             self.log = opt['Logger']
         else:
+            #self.log = init_logger(opt['outfname'])
             self.log = logging.getLogger(__name__)
 
         self.opt = opt
@@ -456,8 +457,8 @@ class Simulation(object):
             self.log.info('NCMC MOVE REJECTED: log_ncmc {} < {}'.format(log_ncmc, randnum) )
             self.nc_sim.context.setPositions(md_state0['positions'])
 
-        self.nc_sim.context._integrator.reset()
         self.nc_sim.currentStep = 0
+        self.nc_sim.context._integrator.reset()
         self.md_sim.context.setVelocitiesToTemperature(temperature)
 
     def simulateNCMC(self, nstepsNC=5000, ncmc_traj=None,
@@ -536,7 +537,7 @@ class Simulation(object):
         if nc_step % self.opt['reporter_interval'] == 0 or nc_step+1 == self.opt['nstepsNC']:
             elapsed = end-start
             elapsedDays = (elapsed/86400.0)
-            elapsedNs = (self.nc_context.getState().getTime()-self._initialSimulationTime).value_in_unit(unit.nanosecond)
+            elapsedNs = (self.nc_sim.context.getState().getTime()-self._initialSimulationTime).value_in_unit(unit.nanosecond)
             speed = (elapsedNs/elapsedDays)
             speed = "%.3g" % speed
             values = [nc_step, speed, self.accept, self.current_iter]

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -14,7 +14,7 @@ from datetime import datetime
 from openmmtools import alchemy
 from blues.integrators import AlchemicalExternalLangevinIntegrator
 import logging
-from reporters import init_logger
+from blues.reporters import init_logger
 
 class SimulationFactory(object):
     """SimulationFactory is used to generate the 3 required OpenMM Simulation
@@ -235,7 +235,7 @@ class Simulation(object):
             self.log = simulations.log
         else:
             self.log = logging.getLogger(__name__)
-            
+
         self.opt = opt
         self.md_sim = simulations.md
         self.alch_sim = simulations.alch

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -102,7 +102,6 @@ class SimulationFactory(object):
         logging.getLogger("openmmtools.alchemy").setLevel(logging.ERROR)
         factory = alchemy.AbsoluteAlchemicalFactory(disable_alchemical_dispersion_correction=True)
         alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices)
-        #alch_region = alchemy.AlchemicalRegion(alchemical_atoms=atom_indices, annihilate_electrostatics=True, annihilate_sterics=True)
         alch_system = factory.create_alchemical_system(system, alch_region)
 
 
@@ -478,7 +477,7 @@ class Simulation(object):
             try:
                 #Attempt anything related to the move before protocol is performed
                 if nc_step == 0:
-                    self.nc_context = self.move_engine.moves[self.move_engine.selected_move].beforeMove(self.nc_sim.context)
+                    self.nc_sim.context = self.move_engine.moves[self.move_engine.selected_move].beforeMove(self.nc_sim.context)
 
                 # Attempt selected MoveEngine Move at the halfway point
                 #to ensure protocol is symmetric
@@ -488,7 +487,6 @@ class Simulation(object):
                     self.nc_sim.context = self.move_engine.runEngine(self.nc_sim.context)
 
                 # Do 1 NCMC step with the integrator
-                #self.nc_sim.context._integrator.step(1)
                 self.nc_sim.step(1)
 
                 ###DEBUG options at every NCMC step
@@ -496,9 +494,6 @@ class Simulation(object):
                     # Print energies at every step
                     work = self.getWorkInfo(self.nc_sim.context._integrator, self.work_keys)
                     self.log.debug('%s' % work)
-                #if ncmc_traj:
-                #self.ncmc_reporter.report(self.nc_sim, self.nc_context.getState(getPositions=True, getVelocities=True))
-
                 #Attempt anything related to the move after protocol is performed
                 if nc_step == nstepsNC-1:
                     self.nc_sim.context = self.move_engine.moves[self.move_engine.selected_move].afterMove(self.nc_sim.context)
@@ -507,9 +502,6 @@ class Simulation(object):
                 self.log.error(e)
                 self.move_engine.moves[self.move_engine.selected_move]._error(self.nc_sim.context)
                 break
-
-            #self.nc_sim.reporters[0].report(self.nc_sim, self.nc_sim.context.getState(getPositions=True))
-            #self._report(start, nc_step)
 
         nc_state1 = self.getStateInfo(self.nc_sim.context, self.state_keys)
         self.setSimState('nc', 'state1', nc_state1)

--- a/blues/tests/test_blues.py
+++ b/blues/tests/test_blues.py
@@ -3,6 +3,7 @@ import unittest, parmed
 from blues import utils
 from blues.moves import RandomLigandRotationMove
 from blues.engine import MoveEngine
+from blues.reporters import init_logger
 from blues.simulation import Simulation, SimulationFactory
 from simtk import openmm
 from openmmtools import testsystems
@@ -21,8 +22,7 @@ class BLUESTester(unittest.TestCase):
                 'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1, 'outfname' : 'blues-test',
-                'platform' : None,
-                'verbose' : True }
+                'platform' : None}
 
 
     def test_moveproperties(self):
@@ -69,8 +69,7 @@ class BLUESTester(unittest.TestCase):
                 'nIter' : 2, 'nstepsNC' : 100, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'NoCutoff', 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1, 'outfname' : 'blues-test',
-                'platform' : None, 'write_ncmc' : False, 'write_move' : False,
-                'verbose' : True }
+                'platform' : None, 'write_move' : False}
 
         testsystem = testsystems.AlanineDipeptideVacuum(constraints=None)
         structure = parmed.openmm.topsystem.load_topology(topology=testsystem.topology,

--- a/blues/tests/test_mc.py
+++ b/blues/tests/test_mc.py
@@ -23,8 +23,7 @@ class BLUESTester(unittest.TestCase):
                 'nIter' : 2, 'nstepsNC' : 4, 'nstepsMD' : 2, 'nprop' : 1,
                 'nonbondedMethod' : 'PME', 'nonbondedCutoff': 10, 'constraints': 'HBonds',
                 'trajectory_interval' : 1, 'reporter_interval' : 1, 'outfname' : 'mc-test',
-                'platform' : None,
-                'verbose' : True }
+                'platform' : None }
 
 
     def test_simulationRun(self):
@@ -35,7 +34,6 @@ class BLUESTester(unittest.TestCase):
                 'trajectory_interval' : 1, 'reporter_interval' : 1,
                 'outfname' : 'mc-test',
                 'platform' : None,
-                'verbose' : True,
                 'constraints' : 'HBonds',
                 'mc_per_iter' : 2 }
 
@@ -103,7 +101,7 @@ class BLUESTester(unittest.TestCase):
             """
             md_state0 = self.current_state['md']['state0']
             md_state1 = self.current_state['md']['state1']
-            log_mc = (md_state1['potential_energy'] - md_state0['potential_energy']) * (-1.0/self.nc_integrator.kT)
+            log_mc = (md_state1['potential_energy'] - md_state0['potential_energy']) * (-1.0/self.nc_sim.context._integrator.kT)
             randnum =  math.log(np.random.random())
 
             if log_mc > randnum:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,8 +14,8 @@ requirements:
     - python
     - pytest
     - setuptools
-    - openmmtools=0.13.0
-    - mdtraj=1.9.1
+    - openmmtools <=0.13.0
+    - mdtraj <=1.9.1
     - openmm >=7.1.1
     - parmed >=2.7.3
 
@@ -23,8 +23,8 @@ requirements:
     - python
     - pytest
     - setuptools
-    - openmmtools=0.13.0
-    - mdtraj=1.9.1
+    - openmmtools <=0.13.0
+    - mdtraj <=1.9.1
     - openmm >=7.1.1
     - parmed >=2.7.3
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,18 +14,19 @@ requirements:
     - python
     - pytest
     - setuptools
-    - openmmtools
-    - mdtraj >=1.8.0
-    - openmm >=7.1.0rc1
+    - openmmtools=0.13.0
+    - mdtraj=1.9.1
+    - openmm >=7.1.1
+    - parmed >=2.7.3
 
   run:
     - python
     - pytest
     - setuptools
-    - openmmtools
-    - mdtraj >=1.8.0
-    - openmm >=7.1.0rc1
-    - parmed
+    - openmmtools=0.13.0
+    - mdtraj=1.9.1
+    - openmm >=7.1.1
+    - parmed >=2.7.3
 
 test:
   requires:


### PR DESCRIPTION
This PR makes some changes to store simulation data for the NCMC portion into the HDF5 file format from MDTraj and makes some changes to the NCMC reporter incorporated from #102 .

One critical change that needs to be closely looked by @sgill2 :
1. Change to explicitly use the `nc_sim` variable, rather than modifying the integrator at a lower level
   - Refer to [lines](https://github.com/MobleyLab/blues/compare/master...hdf5#diff-3c46bef0e4bdea1cebbb3cbc654c214bL255) in the `simulation.py` code.
   - This makes it so that any reporter can be appended to the Simulation object, so that explicit calls to the reporter do not have to be made Ref. [example](https://github.com/MobleyLab/blues/compare/master...hdf5#diff-3c46bef0e4bdea1cebbb3cbc654c214bL505)

The `BLUESHDF5Reporter` and `BLUESHDF5TrajectoryFile` inherit/draw from the `mdtraj.HDF5TrajectoryFile` code with modifications to make it python3 compatible (mainly storing strings as `numpy.string_()` instead) and store import additional data for our use case. 

To use the HDF5 reporter:
```
from reporters import BLUESHDF5Reporter
ncmc_reporter = BLUESHDF5Reporter(file='tolwat-coords.h5',
                                    reportInterval=1,
                                    coordinates=True, frame_indices=[1,opt['nstepsNC']],
                                    time=False, cell=True, temperature=False,
                                    potentialEnergy=False, kineticEnergy=False,
                                    velocities=False, atomSubset=None,
                                    protocolWork=True, alchemicalLambda=True,
                                    parameters=opt, environment=True)
simulations.nc.reporters.append(ncmc_reporter)
```
Notes on arguments for the BLUESHDF5Reporter:
-  `frame_indices = [1, opt['nstepsNC']]` will fill the coordinates array with 0s except for the first and last frame (this will dramatically save space).
    - Toluene in a water box (1845 atoms)
      - Storing 1000 frames gives a filesize of 15.8MB 
      - Keeping first/last coordinates gives a filesize of 376KB (97.6% reduction)
   - Toluene bound to T4 lysozyme (23364 atoms)
      - Storing 100 frames gives 23.3MB
      - First/last gives 2.8MB (87.9% reduction)
- `atomSubset` will take atom indices and will only write the coordinates for these atoms (also saves space).
    - For toluene bound to T4 lysozyme, storing only the first/last coordinates of the protein+ligand atoms brings the filesize 288KB (98.7% reduction)
- `protocolWork = True` will write the accumulated `protocol_work`  at every NCMC step (default) or set by `reportInterval`.
- `alchemicalLambda=True` will write the lambda value at every NCMC step.
- `parameters` is meant to store the dictionary containing the simulation parameters.
- `environment=True` will attempt to execute the command `conda env export --no-build` and store the users conda environment.



