### PR TITLE
Critical bug fix in alchemical correction term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Packages
+*.txt
+*.log
+*.egg
+*.egg-info
+.pytest_cache
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ develop-eggs
 lib
 lib64
 __pycache__
+.ipynb_checkpoints

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 
 This package takes advantage of non-equilibrium candidate Monte Carlo moves (NCMC) to help sample between different ligand binding modes.
 
-Latest release: [![DOI](https://zenodo.org/badge/62096511.svg)](https://zenodo.org/badge/latestdoi/62096511)
+Latest release:
+[![Build Status](https://travis-ci.org/MobleyLab/blues.svg?branch=master)](https://travis-ci.org/MobleyLab/blues)
+[![Anaconda-Server Badge](https://anaconda.org/mobleylab/blues/badges/version.svg)](https://anaconda.org/mobleylab/blues)
+[![Anaconda-Server Badge](https://anaconda.org/mobleylab/blues/badges/latest_release_date.svg)](https://anaconda.org/mobleylab/blues)
+ [![DOI](https://zenodo.org/badge/62096511.svg)](https://zenodo.org/badge/latestdoi/62096511)
 
 ## Citations
 #### Publication

--- a/blues/rotmove_cuda.yaml
+++ b/blues/rotmove_cuda.yaml
@@ -53,6 +53,17 @@ simulation:
   nIter: 5
   nstepsMD: 1000
   nstepsNC: 1000
+  #Defauilt
+  nprop: 1
+  propLambda: 0.3
+  ###Advanced: Add additional relaxation steps in NCMC simulation###
+  # Suggested options for nprop and nstepsNC
+  # nprop: 2 nstepsNC: Any value in increments of 1000
+  # nprop: 3 nstepsNC: 3000, 6000, 11000, 14000, 17000, 22000, 25000
+  # nprop: 4 nstepsNC: 1000, 7000, 8000, 14000, 15000, 21000, 22000
+  # nprop: 5 nstepsNC: 9000, 13000, 17000
+  ##################################################################
+
 
 md_reporters:
   state:

--- a/blues/rotmove_cuda.yaml
+++ b/blues/rotmove_cuda.yaml
@@ -26,10 +26,10 @@ system:
   splitDihedrals: False
 
   alchemical:
-    softcore_alpha: 0.0001 #Default: 0.5
+    softcore_alpha: 0.5
     softcore_a : 1
     softcore_b : 1
-    softcore_c : 48 #Default: 6
+    softcore_c : 6
     softcore_beta : 0.0
     softcore_d : 1
     softcore_e : 1

--- a/blues/settings.py
+++ b/blues/settings.py
@@ -172,8 +172,8 @@ class Settings(object):
     @staticmethod
     def check_SystemModifications(config):
         """
-        Given a dict (config), check the parameters relate dto freezing or
-        restraining the system.
+        Given a dict (config), check the parameters related to freezing or
+        restraining the system. Requires loading parmed.Structure from YAML.
         """
         # Check Amber Selections
         if 'freeze' in config.keys():
@@ -278,9 +278,10 @@ class Settings(object):
             # Set top level configuration parameters
             config = Settings.set_Output(config)
             config = Settings.set_Logger(config)
-            if 'structure' in config: config = Settings.set_Structure(config)
+            if 'structure' in config:
+                config = Settings.set_Structure(config)
+                Settings.check_SystemModifications(config)
             config = Settings.set_Units(config)
-            Settings.check_SystemModifications(config)
             config = Settings.set_Apps(config)
             config = Settings.set_ncmcSteps(config)
             config = Settings.set_Reporters(config)

--- a/blues/sidechain_cuda.yaml
+++ b/blues/sidechain_cuda.yaml
@@ -7,7 +7,7 @@
 
 output_dir: vacDivaline-test
 outfname: vacDivaline
-logger_level: info 
+logger_level: info
 
 structure:
   filename: tests/data/vacDivaline.prmtop
@@ -25,10 +25,10 @@ system:
   splitDihedrals: False
 
   alchemical:
-    softcore_alpha: 0.0001 #Default: 0.5
+    softcore_alpha: 0.5
     softcore_a : 1
     softcore_b : 1
-    softcore_c : 48 #Default: 6
+    softcore_c : 6
     softcore_beta : 0.0
     softcore_d : 1
     softcore_e : 1

--- a/blues/sidechain_cuda.yaml
+++ b/blues/sidechain_cuda.yaml
@@ -47,7 +47,17 @@ simulation:
   nIter: 5
   nstepsMD: 1000
   nstepsNC: 1000
-
+  #Defauilt
+  nprop: 1
+  propLambda: 0.3
+  ###Advanced: Add additional relaxation steps in NCMC simulation###
+  # Suggested options for nprop and nstepsNC
+  # nprop: 2 nstepsNC: Any value in increments of 1000
+  # nprop: 3 nstepsNC: 3000, 6000, 11000, 14000, 17000, 22000, 25000
+  # nprop: 4 nstepsNC: 1000, 7000, 8000, 14000, 15000, 21000, 22000
+  # nprop: 5 nstepsNC: 9000, 13000, 17000
+  ##################################################################
+  
 md_reporters:
   state:
     reportInterval: 250

--- a/blues/simulation.py
+++ b/blues/simulation.py
@@ -836,19 +836,12 @@ class BLUESSimulation(object):
         self._set_stateTable_('md', 'state0', md_state0)
         self._md_sim.currentIter = currentIter
 
-        #TODO: CHECK SHOULD THIS BE BEFORE OR AFTER SYNCING FROM MD?
-        #ncmc_state0 = self.getStateFromContext(self._ncmc_sim.context, self._state_keys_, currentIter)
-        #self._set_stateTable_('ncmc', 'state0', ncmc_state0)
-        #self._ncmc_sim.currentIter = currentIter
-
-        # Replace ncmc context data from the md context
-        self._ncmc_sim.context = self.setContextFromState(self._ncmc_sim.context, md_state0)
-
-        #TODO: CHECK SHOULD THIS BE BEFORE OR AFTER SYNCING FROM MD?
-        # IMPACTS ALCHEMICAL CORRECTION CALCULATION?
         ncmc_state0 = self.getStateFromContext(self._ncmc_sim.context, self._state_keys_)
         self._set_stateTable_('ncmc', 'state0', ncmc_state0)
         self._ncmc_sim.currentIter = currentIter
+
+        # Replace ncmc context data from the md context
+        self._ncmc_sim.context = self.setContextFromState(self._ncmc_sim.context, md_state0)
 
     def _stepNCMC_(self, nstepsNC, moveStep, move_engine=None):
         """Function that advances the NCMC simulation."""
@@ -878,7 +871,7 @@ class BLUESSimulation(object):
                 # Do 1 NCMC step with the integrator
                 self._ncmc_sim.step(1)
 
-                ###DEBUG options at every NCMC step
+                #DEBUG options at every NCMC step
                 logger.debug('%s' % self.getIntegratorInfo(self._ncmc_sim.context._integrator, self._integrator_keys_))
 
                 #Attempt anything related to the move after protocol is performed
@@ -909,10 +902,7 @@ class BLUESSimulation(object):
         alch_PE = self._alch_sim.context.getState(getEnergy=True).getPotentialEnergy()
 
         correction_factor = (ncmc_state0_PE - md_state0_PE + alch_PE - ncmc_state1['potential_energy']) * (-1.0/self._ncmc_sim.context._integrator.kT)
-
-        #print('Alchemical Correction', correction_factor)
-        #print(ncmc_state0_PE, md_state0_PE)
-        #print(ncmc_state0_PE - md_state0_PE)
+        logger.debug('Alchemical Correction = %.6f' % correction_factor)
 
         return correction_factor
 

--- a/notebooks/BLUES_tutorial.ipynb
+++ b/notebooks/BLUES_tutorial.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "# YAML Configuration\n",
     "\n",
-    "BLUES can be configured in either pure python through dictionaries of the appropriate parameters or using a YAML file (which is converted to a dict under the hood). Below we will walk through the keywords for configuring BLUES. An example YAML configuration file can be found in `blues_cuda.yaml`. \n",
+    "BLUES can be configured in either pure python through dictionaries of the appropriate parameters or using a YAML file (which is converted to a dict under the hood). Below we will walk through the keywords for configuring BLUES. An example YAML configuration file can be found in `rotmove_cuda.yaml`. \n",
     "\n",
     "Note: Code blocks in this notebook denoted with ------ indicate a section from a YAML configuration file."
    ]
@@ -203,8 +203,8 @@
     "```\n",
     "\n",
     "### (Optional) Additional relaxation steps in the NCMC simulation\n",
-    "Keywords **`nprop`** and **`prop_lambda`** allow you to add additional relxation steps between a set range in the lambda schedule for the alchemical process in the NCMC simulation. \n",
-    "Setting **`prop_lambda`** to 0.3 will select a lambda range of -/+ 0.3 from the midpoint (0.5), giving [0.2, 0.8]. During the alchemical process, when lambda is between 0.2 to 0.8, **`nprop`** controls the number of additional relaxation steps to add at each lambda step (change in lambda). Additional relaxation steps has been show to increase acceptance proposed NCMC moves.\n",
+    "Keywords **`nprop`** and **`propLambda`** allow you to add additional relxation steps between a set range in the lambda schedule for the alchemical process in the NCMC simulation. \n",
+    "Setting **`propLambda`** to 0.3 will select a lambda range of -/+ 0.3 from the midpoint (0.5), giving [0.2, 0.8]. During the alchemical process, when lambda is between 0.2 to 0.8, **`nprop`** controls the number of additional relaxation steps to add at each lambda step (change in lambda). Additional relaxation steps has been show to increase acceptance proposed NCMC moves.\n",
     "```\n",
     "----------\n",
     "simulation:\n",
@@ -217,7 +217,7 @@
     "  nstepsNC: 10000\n",
     "  pressure: 1 * atmospheres\n",
     "  nprop: 3\n",
-    "  prop_lambda: 0.3\n",
+    "  propLambda: 0.3\n",
     "----------\n",
     "```\n",
     "\n",
@@ -981,9 +981,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:simopt]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-simopt-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -995,7 +995,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Somewhere along the line I had switched to using the incorrect state in the NCMC simulation for computing the alchemical correction term. This fixes a bug in computing the alchemical correction term in this [section](https://github.com/MobleyLab/blues/blob/ee8d9b2c31e34c090808f7dbc5c0ca97b6ade195/blues/simulation.py#L839-L851)

