### PR TITLE
Fix for conda build not installing package dependencies from setup.py

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: {{ build_number }}
   noarch: generic
   preserve_egg_dir: True
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:


### PR DESCRIPTION
For some reason, travis fails during the build phase after being merged to master.

It throws this error
`RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml`

The fix according to this [conda issue](https://github.com/conda/conda/issues/508) appears to be adding certain flags in the call to setup.py

` python setup.py install --single-version-externally-managed --record=record.txt`