### PR TITLE
Fix for ReadTheDocs building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ conda:
 
 python:
     version: 3.5
-    pip_install: true
+    setup_py_install: true
     extra_requirements:
     - tests
     - docs


### PR DESCRIPTION
A change in how ReadTheDocs handles pip installation caused building the documentation to fail. See related issue: https://github.com/rtfd/readthedocs.org/issues/5545

This fixes it.