### PR TITLE
Clean up and update installation instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ conda install -c mobleylab blues
 Install from source (NOT RECOMMENDED)
 ```bash
 # Clone the BLUES repository
-git clone https://github.com/MobleyLab/blues.git blues
+git clone https://github.com/MobleyLab/blues.git ./blues
 
 # Install some dependencies
 conda install -c omnia -c conda-forge openmmtools=0.15.0 openmm=7.4.2 numpy cython
 
-# Optional: To use SideChainMove class, OpenEye toolkits and related tools are requried
+# Optional: To use SideChainMove class, OpenEye toolkits and related tools are requried (requires OpenEye License)
 conda install -c openeye/label/Orion -c omnia oeommtools
-
-# Requires OpenEye License
 conda install -c openeye openeye-toolkits
 
 # Install BLUES package from the top directory
@@ -110,7 +108,6 @@ One important non-obvious thing to note about the CombinationMove class is that 
 - [Version 0.2.1](https://doi.org/10.5281/zenodo.1288925): Bug fix in alchemical correction term
 - [Version 0.2.2](https://doi.org/10.5281/zenodo.1324415): Bug fixes for OpenEye tests and restarting from the YAML; enhancements to the Logger and package installation.
 - [Version 0.2.3](https://zenodo.org/badge/latestdoi/62096511): Improvements to Travis CI, fix in velocity synicng, and add tests for checking freezing selection.
-https://doi.org/10.5281/zenodo.2672932
 - [Version 0.2.4](https://doi.org/10.5281/zenodo.2672932): Added a simple test system (charged ethylene) which can run quickly on CPU.
 - [Version 0.2.5](https://doi.org/10.5281/zenodo.4118606): This contains numerous small changes/fixes since the v0.2.4 release, but most notably includes the introduction of water hopping as described at https://doi.org/10.26434/chemrxiv.12429464.v1
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,9 @@ Latest release:
 * `notebooks` - Jupyter notebooks for testing/development
 
 ## Prerequisites
-BLUES is compatible with MacOSX/Linux with Python>=3.5 (blues<=1.1 still works with Python 2.7)
+BLUES is compatible with MacOSX/Linux with Python=3.6
 Install [miniconda](http://conda.pydata.org/miniconda.html) according to your system.
 
-## Requirements
-Starting from v1.2, you will need the OpenEye toolkits and related tools:
-```bash
-conda install -c openeye/label/Orion -c omnia oeommtools packmol
-
-# Requires OpenEye License
-conda install -c openeye openeye-toolkits
-```
 
 ## Installation
 [ReadTheDocs: Installation](https://mobleylab-blues.readthedocs.io/en/latest/installation.html)
@@ -46,24 +38,25 @@ Recommended: Install releases from conda
 conda install -c mobleylab blues
 ```
 
-Development builds: contains latest commits/PRs not yet issued in a point release
-```bash
-conda install -c mobleylab/label/dev blues
-```
-
 Install from source (NOT RECOMMENDED)
 ```bash
 # Clone the BLUES repository
-git clone git@github.com:MobleyLab/blues.git
+git clone https://github.com/MobleyLab/blues.git blues
 
 # Install some dependencies
-conda install -c omnia -c conda-forge openmmtools=0.15.0 openmm=7.2.2 numpy cython
+conda install -c omnia -c conda-forge openmmtools=0.15.0 openmm=7.4.2 numpy cython
+
+# Optional: To use SideChainMove class, OpenEye toolkits and related tools are requried
+conda install -c openeye/label/Orion -c omnia oeommtools
+
+# Requires OpenEye License
+conda install -c openeye openeye-toolkits
 
 # Install BLUES package from the top directory
 pip install -e .
 
-# To validate your BLUES installation run the tests.
-pip install -e .[tests]
+# To validate your BLUES installation run the tests (need pytest)
+cd blues/tests
 pytest -v -s
 ```
 
@@ -117,6 +110,9 @@ One important non-obvious thing to note about the CombinationMove class is that 
 - [Version 0.2.1](https://doi.org/10.5281/zenodo.1288925): Bug fix in alchemical correction term
 - [Version 0.2.2](https://doi.org/10.5281/zenodo.1324415): Bug fixes for OpenEye tests and restarting from the YAML; enhancements to the Logger and package installation.
 - [Version 0.2.3](https://zenodo.org/badge/latestdoi/62096511): Improvements to Travis CI, fix in velocity synicng, and add tests for checking freezing selection.
+https://doi.org/10.5281/zenodo.2672932
+- [Version 0.2.4](https://doi.org/10.5281/zenodo.2672932): Added a simple test system (charged ethylene) which can run quickly on CPU.
+- [Version 0.2.5](https://doi.org/10.5281/zenodo.4118606): This contains numerous small changes/fixes since the v0.2.4 release, but most notably includes the introduction of water hopping as described at https://doi.org/10.26434/chemrxiv.12429464.v1
 
 ## Acknowledgements
 We would like to thank Patrick Grinaway and John Chodera for their basic code framework for NCMC in OpenMM (see https://github.com/choderalab/perses/tree/master/perses/annihilation), and John Chodera and Christopher Bayly for their helpful discussions.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,19 @@ Install [miniconda](http://conda.pydata.org/miniconda.html) according to your sy
 [ReadTheDocs: Installation](https://mobleylab-blues.readthedocs.io/en/latest/installation.html)
 
 Recommended: Install releases from conda
+
+For MacOSX users:
 ```bash
+conda install -c mobleylab blues
+```
+
+For Linux users:
+```bash
+# Install OpenEye toolkits and related tools first
+conda install -c openeye/label/Orion -c omnia oeommtools
+conda install -c openeye openeye-toolkits
+
+# Then install BLUES
 conda install -c mobleylab blues
 ```
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,8 @@ build:
   number: 0 # Build number and string do not work together.
   #string: py{{ py }}_a1 # Alpha version 1.
   skip: True # [win or py27 or py35]
-  noarch: python
+  noarch: generic
+  #  noarch: python
   script:
     - ${PYTHON}  -m pip install .
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -5,11 +5,21 @@ package:
 source:
   path : ../..
 
-build:
-  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
+  #build:
+  #  number: {{ environ.get('GIT_DESCRIBE_NUMBER', 0) }}
   #string: py{{ CONDA_PY }}_{{ environ.get('GIT_BUILD_STR', '') }} # Ex. `py35_5_g6aaba2d`
-  string: py{{ CONDA_PY }}{{ environ.get('GIT_DESCRIBE_HASH', 'ERROR') }}_{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }} #Ex. `py35g6aaba2d_5`
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  #string: py{{ CONDA_PY }}{{ environ.get('GIT_DESCRIBE_HASH', 'ERROR') }}_{{ environ.get('GIT_DESCRIBE_NUMBER', 0) }} #Ex. `py35g6aaba2d_5`
+  #script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+
+build:
+  preserve_egg_dir: True
+  number: 0 # Build number and string do not work together.
+  #string: py{{ py }}_a1 # Alpha version 1.
+  skip: True # [win or py27 or py35]
+  noarch: python
+  script:
+    - ${PYTHON}  -m pip install .
+
 
 requirements:
   host:
@@ -19,21 +29,26 @@ requirements:
 
   build:
     - python
-    - pytest
-    - setuptools
-    - openmmtools >=0.15.0
-    - mdtraj
-    - openmm >=7.2.2
-    - parmed
-    - pymbar
-    - netcdf4
-    - pyyaml
     - pip
+    - openeye-toolkits
 
   run:
-  {% for package in resolved_packages('build') %}
-    - {{ package }}
-  {% endfor %}
+    - python
+    - pytest
+    - setuptools
+    - openmmtools==0.15.0
+    - oeommtools # >=0.1.16
+    - openeye-toolkits
+    - mdtraj
+    - openmm #>=7.2.2
+    - parmed
+    - netcdf4
+    - hdf5
+    - pyyaml
+    - pip
+    - numpy
+    - cython
+      
 
 test:
   requires:

--- a/docs/BLUES_tutorial.ipynb
+++ b/docs/BLUES_tutorial.ipynb
@@ -443,8 +443,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from blues.moves import RandomLigandRotationMove\n",
-    "from blues.engine import MoveEngine\n",
+    "from blues.moves import RandomLigandRotationMove, MoveEngine\n",
     "from blues.simulation import *\n",
     "from blues.settings import *"
    ]
@@ -990,7 +989,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1004,7 +1003,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ==================
 
-BLUES is compatible with MacOSX/Linux with Python>=3.5 (blues<1.1 still works with Python 2.7)
+BLUES is compatible with MacOSX/Linux with Python=3.6.
 
 This is a python tool kit with a few dependencies. We recommend installing
 `miniconda <http://conda.pydata.org/miniconda.html>`_. Then you can create an
@@ -9,35 +9,29 @@ environment with the following commands:
 
 .. code-block:: bash
 
-    conda create -n blues python=3.5
+    conda create -n blues python=3.6
     source activate blues
 
 Stable Releases
 ---------------
 The recommended way to install BLUES would be to install from conda.
 
+For MacOSX users:
 .. code-block:: bash
 
     conda install -c mobleylab blues
 
-
-Development Builds
-------------------
-Alternatively, you can install the latest development build. Development builds
-contain the latest commits/PRs not yet issued in a point release.
-
+For Linux users:
+Install OpenEye toolkits and related tools first
 .. code-block:: bash
 
-    conda install -c mobleylab/label/dev blues
-
-
-In order to use the `SideChainMove` class you will need OpenEye Toolkits and
-some related tools.
-
-.. code-block:: bash
-
-    conda install -c openeye/label/Orion -c omnia oeommtools packmol
+    conda install -c openeye/label/Orion -c omnia oeommtools
     conda install -c openeye openeye-toolkits
+
+Then install BLUES
+.. code-block:: bash
+
+    conda install -c mobleylab blues
 
 
 Source Installation
@@ -47,13 +41,14 @@ source code.
 
 .. code-block:: bash
 
-    git clone https://github.com/MobleyLab/blues.git
-    conda install -c omnia -c conda-forge openmmtools=0.15.0 openmm=7.2.2 numpy cython
+    git clone https://github.com/MobleyLab/blues.git ./blues
+    conda install -c omnia -c conda-forge openmmtools=0.15.0 openmm=7.4.2 numpy cython
+    conda install -c openeye/label/Orion -c omnia oeommtools
+    conda install -c openeye openeye-toolkits
     pip install -e .
 
 To validate your BLUES installation run the tests.
 
 .. code-block:: bash
-
-   pip instal -e .[tests]
+   cd blues/tests
    pytest -v -s

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,26 +9,30 @@ environment with the following commands:
 
 .. code-block:: bash
 
-    conda create -n blues python=3.6
-    source activate blues
+   conda create -n blues python=3.6
+   source activate blues
 
 Stable Releases
 ---------------
 The recommended way to install BLUES would be to install from conda.
 
 For MacOSX users:
+Install BLUES with dependencies together.
+
 .. code-block:: bash
 
     conda install -c mobleylab blues
 
 For Linux users:
-Install OpenEye toolkits and related tools first
+Install OpenEye toolkits and related tools first.
+
 .. code-block:: bash
 
     conda install -c openeye/label/Orion -c omnia oeommtools
     conda install -c openeye openeye-toolkits
 
-Then install BLUES
+Then install BLUES.
+
 .. code-block:: bash
 
     conda install -c mobleylab blues
@@ -50,5 +54,5 @@ source code.
 To validate your BLUES installation run the tests.
 
 .. code-block:: bash
-   cd blues/tests
-   pytest -v -s
+    cd blues/tests
+    pytest -v -s

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,5 +54,6 @@ source code.
 To validate your BLUES installation run the tests.
 
 .. code-block:: bash
+
     cd blues/tests
     pytest -v -s

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     license='MIT',
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     url='https://github.com/MobleyLab/blues',
     platforms=['Linux-64', 'Mac OSX-64', 'Unix-64'],
     classifiers=CLASSIFIERS.splitlines(),
@@ -80,6 +80,13 @@ setup(
         'pytest-cov',
         'pytest-pep8',
         'tox',
+    ],
+    install_requires=[
+        'openmmtools==0.15.0',
+        'oeommtools>=0.1.16',
+        'openmm>=7.2.2',
+        'numpy>=1.15.2',
+        'cython>=0.28.5'
     ],
     zip_safe=False,
     include_package_data=True)


### PR DESCRIPTION
## Description
This PR focuses on some cleanup and update work of installation instructions through conda and GitHub. 
A few key points:
- Remove languages of old BLUES version which supports Python 2.7. 
- Specify that the current BLUES version only supports Python 3.6.
- Clarify installation instructions for MacOSX and Linux users.
- Cleanup and update instructions of installation BLUES through Github clone. 
- Update `meta.yaml` file so now the package has supported python version shown in the package name.
- Update the installation instructions page on readthedoc site.
- Add description of main changes in v0.2.4 and v0.2.5.
- Fix an out-of-date line in the tutorial (jupyter notebook).
- Remove `dev` version BLUES installation instructions for now (since it is not updated on anaconda server and it is the same as the `main` version we have now. In the future, I will figure out how to prepare packages for `dev` and upload it to the server in an easy/automatic way. 

## Status
- The newly prepared package is verified and I have successfully installed it through conda on both MacOSX and Linux and through GitHub.
- [ ] Ready to go